### PR TITLE
feat: add side by side testing

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python: ["3.10", "3.11"]
+        python: ["3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ spark = SparkSession.builder.remote("sc://localhost:50051").getOrCreate()
 # Use the spark session normally.
 ```
 
-You'll find that the [usage examples on the Spark website](https://spark.apache.org/docs/latest/spark-connect-overview.html#use-spark-connect-in-standalone-applications) also apply to the gateway without any modification.
+You'll find that the [usage examples on the Spark website](https://spark.apache.org/docs/latest/spark-connect-overview.html#use-spark-connect-in-standalone-applications) also apply to the gateway without any modification.  You may also run the provided demo located at ```src/gateway/demo/client_demo.py```.

--- a/src/gateway/adbc/backend.py
+++ b/src/gateway/adbc/backend.py
@@ -6,7 +6,6 @@ import adbc_driver_duckdb.dbapi
 import duckdb
 import pyarrow
 from pyarrow import substrait
-# import datafusion.substrait
 
 from substrait.gen.proto import plan_pb2
 
@@ -46,31 +45,13 @@ class AdbcBackend:
         query_result = reader.read_all()
         return query_result
 
-    '''
-    def execute_with_datafusion(self, plan: 'plan_pb2.Plan') -> pyarrow.lib.Table:
-        """Executes the given Substrait plan against Datafusion."""
-        ctx = datafusion.SessionContext()
-        # TODO -- Handle registration by scanning and then rewriting the plan.
-        ctx.register_parquet("demotable", 'artists.parquet')
-
-        plan_data = plan.SerializeToString()
-        substrait_plan = datafusion.substrait.substrait.serde.deserialize_bytes(plan_data)
-        logical_plan = datafusion.substrait.substrait.consumer.from_substrait_plan(
-            ctx, substrait_plan
-        )
-
-        # Create a DataFrame from a deserialized logical plan
-        df_result = ctx.create_dataframe_from_logical_plan(logical_plan)
-        return df_result.to_arrow_table()
-    '''
-
     def execute(self, plan: 'plan_pb2.Plan', options: BackendOptions) -> pyarrow.lib.Table:
         """Executes the given Substrait plan."""
         match options.backend:
             case Backend.ARROW:
                 return self.execute_with_arrow(plan)
             case Backend.DATAFUSION:
-                return self.execute_with_datafusion(plan)
+                raise ValueError('Datafusion support has been temporarily removed (see #16).')
             case Backend.DUCKDB:
                 if options.use_adbc:
                     return self.execute_with_duckdb_over_adbc(plan)

--- a/src/gateway/adbc/backend.py
+++ b/src/gateway/adbc/backend.py
@@ -6,7 +6,7 @@ import adbc_driver_duckdb.dbapi
 import duckdb
 import pyarrow
 from pyarrow import substrait
-import datafusion.substrait
+# import datafusion.substrait
 
 from substrait.gen.proto import plan_pb2
 
@@ -46,6 +46,7 @@ class AdbcBackend:
         query_result = reader.read_all()
         return query_result
 
+    '''
     def execute_with_datafusion(self, plan: 'plan_pb2.Plan') -> pyarrow.lib.Table:
         """Executes the given Substrait plan against Datafusion."""
         ctx = datafusion.SessionContext()
@@ -61,6 +62,7 @@ class AdbcBackend:
         # Create a DataFrame from a deserialized logical plan
         df_result = ctx.create_dataframe_from_logical_plan(logical_plan)
         return df_result.to_arrow_table()
+    '''
 
     def execute(self, plan: 'plan_pb2.Plan', options: BackendOptions) -> pyarrow.lib.Table:
         """Executes the given Substrait plan."""

--- a/src/gateway/adbc/backend.py
+++ b/src/gateway/adbc/backend.py
@@ -6,8 +6,7 @@ import adbc_driver_duckdb.dbapi
 import duckdb
 import pyarrow
 from pyarrow import substrait
-from datafusion import SessionContext
-from datafusion import substrait as ds
+import datafusion.substrait
 
 from substrait.gen.proto import plan_pb2
 
@@ -49,13 +48,13 @@ class AdbcBackend:
 
     def execute_with_datafusion(self, plan: 'plan_pb2.Plan') -> pyarrow.lib.Table:
         """Executes the given Substrait plan against Datafusion."""
-        ctx = SessionContext()
+        ctx = datafusion.SessionContext()
         # TODO -- Handle registration by scanning and then rewriting the plan.
         ctx.register_parquet("demotable", 'artists.parquet')
 
         plan_data = plan.SerializeToString()
-        substrait_plan = ds.substrait.serde.deserialize_bytes(plan_data)
-        logical_plan = ds.substrait.consumer.from_substrait_plan(
+        substrait_plan = datafusion.substrait.substrait.serde.deserialize_bytes(plan_data)
+        logical_plan = datafusion.substrait.substrait.consumer.from_substrait_plan(
             ctx, substrait_plan
         )
 

--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -5,6 +5,7 @@ import dataclasses
 from gateway.adbc.backend_options import BackendOptions, Backend
 
 
+# pylint: disable=too-many-instance-attributes
 @dataclasses.dataclass
 class ConversionOptions:
     """Holds all the possible conversion options."""

--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -41,5 +41,4 @@ def duck_db():
     """Standard options to connect to a DuckDB backend."""
     options = ConversionOptions(backend=BackendOptions(Backend.DUCKDB))
     options.return_names_with_types = True
-    # options.use_project_emit_workaround = True
     return options

--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -39,5 +39,5 @@ def duck_db():
     """Standard options to connect to a DuckDB backend."""
     options = ConversionOptions(backend=BackendOptions(Backend.DUCKDB))
     options.return_names_with_types = True
-    #options.use_project_emit_workaround = True
+    # options.use_project_emit_workaround = True
     return options

--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -25,6 +25,8 @@ class ConversionOptions:
 
         self.return_names_with_types = False
 
+        self.implement_show_string = False
+
         self.backend = backend
 
 

--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -39,5 +39,5 @@ def duck_db():
     """Standard options to connect to a DuckDB backend."""
     options = ConversionOptions(backend=BackendOptions(Backend.DUCKDB))
     options.return_names_with_types = True
-    options.use_project_emit_workaround = True
+    #options.use_project_emit_workaround = True
     return options

--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -39,4 +39,5 @@ def duck_db():
     """Standard options to connect to a DuckDB backend."""
     options = ConversionOptions(backend=BackendOptions(Backend.DUCKDB))
     options.return_names_with_types = True
+    options.use_project_emit_workaround = True
     return options

--- a/src/gateway/converter/data/00001.splan
+++ b/src/gateway/converter/data/00001.splan
@@ -45,25 +45,26 @@ extensions {
 relations {
   root {
     input {
-      fetch {
+      project {
         common {
-          direct {
+          emit {
+            output_mapping: 2
           }
         }
         input {
-          sort {
+          fetch {
             common {
               direct {
               }
             }
             input {
-              aggregate {
+              sort {
                 common {
                   direct {
                   }
                 }
                 input {
-                  filter {
+                  aggregate {
                     common {
                       direct {
                       }
@@ -75,7 +76,7 @@ relations {
                           }
                         }
                         input {
-                          project {
+                          filter {
                             common {
                               direct {
                               }
@@ -93,110 +94,138 @@ relations {
                                       }
                                     }
                                     input {
-                                      read {
+                                      project {
                                         common {
                                           direct {
                                           }
                                         }
-                                        base_schema {
-                                          names: "mbid"
-                                          names: "artist_mb"
-                                          names: "artist_lastfm"
-                                          names: "country_mb"
-                                          names: "country_lastfm"
-                                          names: "tags_mb"
-                                          names: "tags_lastfm"
-                                          names: "listeners_lastfm"
-                                          names: "scrobbles_lastfm"
-                                          names: "ambiguous_artist"
-                                          struct {
-                                            types {
+                                        input {
+                                          read {
+                                            common {
+                                              direct {
+                                              }
+                                            }
+                                            base_schema {
+                                              names: "mbid"
+                                              names: "artist_mb"
+                                              names: "artist_lastfm"
+                                              names: "country_mb"
+                                              names: "country_lastfm"
+                                              names: "tags_mb"
+                                              names: "tags_lastfm"
+                                              names: "listeners_lastfm"
+                                              names: "scrobbles_lastfm"
+                                              names: "ambiguous_artist"
+                                              struct {
+                                                types {
+                                                  string {
+                                                    nullability: NULLABILITY_REQUIRED
+                                                  }
+                                                }
+                                                types {
+                                                  string {
+                                                    nullability: NULLABILITY_NULLABLE
+                                                  }
+                                                }
+                                                types {
+                                                  string {
+                                                    nullability: NULLABILITY_NULLABLE
+                                                  }
+                                                }
+                                                types {
+                                                  string {
+                                                    nullability: NULLABILITY_NULLABLE
+                                                  }
+                                                }
+                                                types {
+                                                  string {
+                                                    nullability: NULLABILITY_NULLABLE
+                                                  }
+                                                }
+                                                types {
+                                                  string {
+                                                    nullability: NULLABILITY_NULLABLE
+                                                  }
+                                                }
+                                                types {
+                                                  string {
+                                                    nullability: NULLABILITY_NULLABLE
+                                                  }
+                                                }
+                                                types {
+                                                  i32 {
+                                                    nullability: NULLABILITY_NULLABLE
+                                                  }
+                                                }
+                                                types {
+                                                  i32 {
+                                                    nullability: NULLABILITY_NULLABLE
+                                                  }
+                                                }
+                                                types {
+                                                  bool {
+                                                    nullability: NULLABILITY_NULLABLE
+                                                  }
+                                                }
+                                                nullability: NULLABILITY_REQUIRED
+                                              }
+                                            }
+                                            local_files {
+                                              items {
+                                                uri_file: "/Users/davids/Desktop/artists.parquet"
+                                                parquet {
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                        expressions {
+                                          scalar_function {
+                                            function_reference: 1
+                                            output_type {
                                               string {
                                                 nullability: NULLABILITY_REQUIRED
                                               }
                                             }
-                                            types {
-                                              string {
-                                                nullability: NULLABILITY_NULLABLE
+                                            arguments {
+                                              value {
+                                                selection {
+                                                  direct_reference {
+                                                    struct_field {
+                                                      field: 6
+                                                    }
+                                                  }
+                                                  root_reference {
+                                                  }
+                                                }
                                               }
                                             }
-                                            types {
-                                              string {
-                                                nullability: NULLABILITY_NULLABLE
+                                            arguments {
+                                              value {
+                                                literal {
+                                                  string: "; "
+                                                }
                                               }
-                                            }
-                                            types {
-                                              string {
-                                                nullability: NULLABILITY_NULLABLE
-                                              }
-                                            }
-                                            types {
-                                              string {
-                                                nullability: NULLABILITY_NULLABLE
-                                              }
-                                            }
-                                            types {
-                                              string {
-                                                nullability: NULLABILITY_NULLABLE
-                                              }
-                                            }
-                                            types {
-                                              string {
-                                                nullability: NULLABILITY_NULLABLE
-                                              }
-                                            }
-                                            types {
-                                              i32 {
-                                                nullability: NULLABILITY_NULLABLE
-                                              }
-                                            }
-                                            types {
-                                              i32 {
-                                                nullability: NULLABILITY_NULLABLE
-                                              }
-                                            }
-                                            types {
-                                              bool {
-                                                nullability: NULLABILITY_NULLABLE
-                                              }
-                                            }
-                                            nullability: NULLABILITY_REQUIRED
-                                          }
-                                        }
-                                        local_files {
-                                          items {
-                                            uri_file: "/Users/davids/Desktop/artists.parquet"
-                                            parquet {
                                             }
                                           }
                                         }
                                       }
                                     }
                                     expressions {
-                                      scalar_function {
-                                        function_reference: 1
-                                        output_type {
-                                          string {
+                                      cast {
+                                        type {
+                                          i32 {
                                             nullability: NULLABILITY_REQUIRED
                                           }
                                         }
-                                        arguments {
-                                          value {
-                                            selection {
-                                              direct_reference {
-                                                struct_field {
-                                                  field: 6
-                                                }
-                                              }
-                                              root_reference {
+                                        input {
+                                          selection {
+                                            direct_reference {
+                                              struct_field {
+                                                field: 7
                                               }
                                             }
-                                          }
-                                        }
-                                        arguments {
-                                          value {
-                                            literal {
-                                              string: "; "
+                                            root_reference {
                                             }
                                           }
                                         }
@@ -207,7 +236,7 @@ relations {
                                 expressions {
                                   cast {
                                     type {
-                                      i32 {
+                                      bool {
                                         nullability: NULLABILITY_REQUIRED
                                       }
                                     }
@@ -215,7 +244,7 @@ relations {
                                       selection {
                                         direct_reference {
                                           struct_field {
-                                            field: 7
+                                            field: 9
                                           }
                                         }
                                         root_reference {
@@ -226,21 +255,31 @@ relations {
                                 }
                               }
                             }
-                            expressions {
-                              cast {
-                                type {
+                            condition {
+                              scalar_function {
+                                function_reference: 2
+                                output_type {
                                   bool {
                                     nullability: NULLABILITY_REQUIRED
                                   }
                                 }
-                                input {
-                                  selection {
-                                    direct_reference {
-                                      struct_field {
-                                        field: 9
+                                arguments {
+                                  value {
+                                    selection {
+                                      direct_reference {
+                                        struct_field {
+                                          field: 9
+                                        }
+                                      }
+                                      root_reference {
                                       }
                                     }
-                                    root_reference {
+                                  }
+                                }
+                                arguments {
+                                  value {
+                                    literal {
+                                      boolean: false
                                     }
                                   }
                                 }
@@ -250,7 +289,7 @@ relations {
                         }
                         condition {
                           scalar_function {
-                            function_reference: 2
+                            function_reference: 3
                             output_type {
                               bool {
                                 nullability: NULLABILITY_REQUIRED
@@ -261,7 +300,7 @@ relations {
                                 selection {
                                   direct_reference {
                                     struct_field {
-                                      field: 9
+                                      field: 6
                                     }
                                   }
                                   root_reference {
@@ -272,7 +311,7 @@ relations {
                             arguments {
                               value {
                                 literal {
-                                  boolean: false
+                                  string: "pop"
                                 }
                               }
                             }
@@ -280,11 +319,24 @@ relations {
                         }
                       }
                     }
-                    condition {
-                      scalar_function {
-                        function_reference: 3
+                    groupings {
+                      grouping_expressions {
+                        selection {
+                          direct_reference {
+                            struct_field {
+                              field: 2
+                            }
+                          }
+                          root_reference {
+                          }
+                        }
+                      }
+                    }
+                    measures {
+                      measure {
+                        function_reference: 4
                         output_type {
-                          bool {
+                          i32 {
                             nullability: NULLABILITY_REQUIRED
                           }
                         }
@@ -293,7 +345,7 @@ relations {
                             selection {
                               direct_reference {
                                 struct_field {
-                                  field: 6
+                                  field: 7
                                 }
                               }
                               root_reference {
@@ -301,76 +353,37 @@ relations {
                             }
                           }
                         }
-                        arguments {
-                          value {
-                            literal {
-                              string: "pop"
-                            }
-                          }
-                        }
                       }
                     }
                   }
                 }
-                groupings {
-                  grouping_expressions {
+                sorts {
+                  expr {
                     selection {
                       direct_reference {
                         struct_field {
-                          field: 2
+                          field: 1
                         }
                       }
                       root_reference {
                       }
                     }
                   }
-                }
-                measures {
-                  measure {
-                    function_reference: 4
-                    output_type {
-                      i32 {
-                        nullability: NULLABILITY_REQUIRED
-                      }
-                    }
-                    arguments {
-                      value {
-                        selection {
-                          direct_reference {
-                            struct_field {
-                              field: 7
-                            }
-                          }
-                          root_reference {
-                          }
-                        }
-                      }
-                    }
-                  }
+                  direction: SORT_DIRECTION_DESC_NULLS_LAST
                 }
               }
             }
-            sorts {
-              expr {
-                selection {
-                  direct_reference {
-                    struct_field {
-                      field: 1
-                    }
-                  }
-                  root_reference {
-                  }
-                }
-              }
-              direction: SORT_DIRECTION_DESC_NULLS_LAST
-            }
+            count: 10
           }
         }
-        count: 10
+        expressions {
+          literal {
+            string: "hiya"
+          }
+        }
       }
     }
-    names: "grouping"
-    names: "# of Listeners"
+    names: "show_string"
   }
 }
 version {

--- a/src/gateway/converter/data/00001.splan
+++ b/src/gateway/converter/data/00001.splan
@@ -45,26 +45,25 @@ extensions {
 relations {
   root {
     input {
-      project {
+      fetch {
         common {
-          emit {
-            output_mapping: 2
+          direct {
           }
         }
         input {
-          fetch {
+          sort {
             common {
               direct {
               }
             }
             input {
-              sort {
+              aggregate {
                 common {
                   direct {
                   }
                 }
                 input {
-                  aggregate {
+                  filter {
                     common {
                       direct {
                       }
@@ -76,7 +75,7 @@ relations {
                           }
                         }
                         input {
-                          filter {
+                          project {
                             common {
                               direct {
                               }
@@ -94,138 +93,110 @@ relations {
                                       }
                                     }
                                     input {
-                                      project {
+                                      read {
                                         common {
                                           direct {
                                           }
                                         }
-                                        input {
-                                          read {
-                                            common {
-                                              direct {
-                                              }
-                                            }
-                                            base_schema {
-                                              names: "mbid"
-                                              names: "artist_mb"
-                                              names: "artist_lastfm"
-                                              names: "country_mb"
-                                              names: "country_lastfm"
-                                              names: "tags_mb"
-                                              names: "tags_lastfm"
-                                              names: "listeners_lastfm"
-                                              names: "scrobbles_lastfm"
-                                              names: "ambiguous_artist"
-                                              struct {
-                                                types {
-                                                  string {
-                                                    nullability: NULLABILITY_REQUIRED
-                                                  }
-                                                }
-                                                types {
-                                                  string {
-                                                    nullability: NULLABILITY_NULLABLE
-                                                  }
-                                                }
-                                                types {
-                                                  string {
-                                                    nullability: NULLABILITY_NULLABLE
-                                                  }
-                                                }
-                                                types {
-                                                  string {
-                                                    nullability: NULLABILITY_NULLABLE
-                                                  }
-                                                }
-                                                types {
-                                                  string {
-                                                    nullability: NULLABILITY_NULLABLE
-                                                  }
-                                                }
-                                                types {
-                                                  string {
-                                                    nullability: NULLABILITY_NULLABLE
-                                                  }
-                                                }
-                                                types {
-                                                  string {
-                                                    nullability: NULLABILITY_NULLABLE
-                                                  }
-                                                }
-                                                types {
-                                                  i32 {
-                                                    nullability: NULLABILITY_NULLABLE
-                                                  }
-                                                }
-                                                types {
-                                                  i32 {
-                                                    nullability: NULLABILITY_NULLABLE
-                                                  }
-                                                }
-                                                types {
-                                                  bool {
-                                                    nullability: NULLABILITY_NULLABLE
-                                                  }
-                                                }
-                                                nullability: NULLABILITY_REQUIRED
-                                              }
-                                            }
-                                            local_files {
-                                              items {
-                                                uri_file: "/Users/davids/Desktop/artists.parquet"
-                                                parquet {
-                                                }
-                                              }
-                                            }
-                                          }
-                                        }
-                                        expressions {
-                                          scalar_function {
-                                            function_reference: 1
-                                            output_type {
+                                        base_schema {
+                                          names: "mbid"
+                                          names: "artist_mb"
+                                          names: "artist_lastfm"
+                                          names: "country_mb"
+                                          names: "country_lastfm"
+                                          names: "tags_mb"
+                                          names: "tags_lastfm"
+                                          names: "listeners_lastfm"
+                                          names: "scrobbles_lastfm"
+                                          names: "ambiguous_artist"
+                                          struct {
+                                            types {
                                               string {
                                                 nullability: NULLABILITY_REQUIRED
                                               }
                                             }
-                                            arguments {
-                                              value {
-                                                selection {
-                                                  direct_reference {
-                                                    struct_field {
-                                                      field: 6
-                                                    }
-                                                  }
-                                                  root_reference {
-                                                  }
-                                                }
+                                            types {
+                                              string {
+                                                nullability: NULLABILITY_NULLABLE
                                               }
                                             }
-                                            arguments {
-                                              value {
-                                                literal {
-                                                  string: "; "
-                                                }
+                                            types {
+                                              string {
+                                                nullability: NULLABILITY_NULLABLE
                                               }
+                                            }
+                                            types {
+                                              string {
+                                                nullability: NULLABILITY_NULLABLE
+                                              }
+                                            }
+                                            types {
+                                              string {
+                                                nullability: NULLABILITY_NULLABLE
+                                              }
+                                            }
+                                            types {
+                                              string {
+                                                nullability: NULLABILITY_NULLABLE
+                                              }
+                                            }
+                                            types {
+                                              string {
+                                                nullability: NULLABILITY_NULLABLE
+                                              }
+                                            }
+                                            types {
+                                              i32 {
+                                                nullability: NULLABILITY_NULLABLE
+                                              }
+                                            }
+                                            types {
+                                              i32 {
+                                                nullability: NULLABILITY_NULLABLE
+                                              }
+                                            }
+                                            types {
+                                              bool {
+                                                nullability: NULLABILITY_NULLABLE
+                                              }
+                                            }
+                                            nullability: NULLABILITY_REQUIRED
+                                          }
+                                        }
+                                        local_files {
+                                          items {
+                                            uri_file: "/Users/davids/Desktop/artists.parquet"
+                                            parquet {
                                             }
                                           }
                                         }
                                       }
                                     }
                                     expressions {
-                                      cast {
-                                        type {
-                                          i32 {
+                                      scalar_function {
+                                        function_reference: 1
+                                        output_type {
+                                          string {
                                             nullability: NULLABILITY_REQUIRED
                                           }
                                         }
-                                        input {
-                                          selection {
-                                            direct_reference {
-                                              struct_field {
-                                                field: 7
+                                        arguments {
+                                          value {
+                                            selection {
+                                              direct_reference {
+                                                struct_field {
+                                                  field: 6
+                                                }
+                                              }
+                                              root_reference {
                                               }
                                             }
-                                            root_reference {
+                                          }
+                                        }
+                                        arguments {
+                                          value {
+                                            literal {
+                                              string: "; "
                                             }
                                           }
                                         }
@@ -236,7 +207,7 @@ relations {
                                 expressions {
                                   cast {
                                     type {
-                                      bool {
+                                      i32 {
                                         nullability: NULLABILITY_REQUIRED
                                       }
                                     }
@@ -244,7 +215,7 @@ relations {
                                       selection {
                                         direct_reference {
                                           struct_field {
-                                            field: 9
+                                            field: 7
                                           }
                                         }
                                         root_reference {
@@ -255,31 +226,21 @@ relations {
                                 }
                               }
                             }
-                            condition {
-                              scalar_function {
-                                function_reference: 2
-                                output_type {
+                            expressions {
+                              cast {
+                                type {
                                   bool {
                                     nullability: NULLABILITY_REQUIRED
                                   }
                                 }
-                                arguments {
-                                  value {
-                                    selection {
-                                      direct_reference {
-                                        struct_field {
-                                          field: 9
-                                        }
-                                      }
-                                      root_reference {
+                                input {
+                                  selection {
+                                    direct_reference {
+                                      struct_field {
+                                        field: 9
                                       }
                                     }
-                                  }
-                                }
-                                arguments {
-                                  value {
-                                    literal {
-                                      boolean: false
+                                    root_reference {
                                     }
                                   }
                                 }
@@ -289,7 +250,7 @@ relations {
                         }
                         condition {
                           scalar_function {
-                            function_reference: 3
+                            function_reference: 2
                             output_type {
                               bool {
                                 nullability: NULLABILITY_REQUIRED
@@ -300,7 +261,7 @@ relations {
                                 selection {
                                   direct_reference {
                                     struct_field {
-                                      field: 6
+                                      field: 9
                                     }
                                   }
                                   root_reference {
@@ -311,7 +272,7 @@ relations {
                             arguments {
                               value {
                                 literal {
-                                  string: "pop"
+                                  boolean: false
                                 }
                               }
                             }
@@ -319,24 +280,11 @@ relations {
                         }
                       }
                     }
-                    groupings {
-                      grouping_expressions {
-                        selection {
-                          direct_reference {
-                            struct_field {
-                              field: 2
-                            }
-                          }
-                          root_reference {
-                          }
-                        }
-                      }
-                    }
-                    measures {
-                      measure {
-                        function_reference: 4
+                    condition {
+                      scalar_function {
+                        function_reference: 3
                         output_type {
-                          i32 {
+                          bool {
                             nullability: NULLABILITY_REQUIRED
                           }
                         }
@@ -345,7 +293,7 @@ relations {
                             selection {
                               direct_reference {
                                 struct_field {
-                                  field: 7
+                                  field: 6
                                 }
                               }
                               root_reference {
@@ -353,37 +301,76 @@ relations {
                             }
                           }
                         }
+                        arguments {
+                          value {
+                            literal {
+                              string: "pop"
+                            }
+                          }
+                        }
                       }
                     }
                   }
                 }
-                sorts {
-                  expr {
+                groupings {
+                  grouping_expressions {
                     selection {
                       direct_reference {
                         struct_field {
-                          field: 1
+                          field: 2
                         }
                       }
                       root_reference {
                       }
                     }
                   }
-                  direction: SORT_DIRECTION_DESC_NULLS_LAST
+                }
+                measures {
+                  measure {
+                    function_reference: 4
+                    output_type {
+                      i32 {
+                        nullability: NULLABILITY_REQUIRED
+                      }
+                    }
+                    arguments {
+                      value {
+                        selection {
+                          direct_reference {
+                            struct_field {
+                              field: 7
+                            }
+                          }
+                          root_reference {
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
-            count: 10
+            sorts {
+              expr {
+                selection {
+                  direct_reference {
+                    struct_field {
+                      field: 1
+                    }
+                  }
+                  root_reference {
+                  }
+                }
+              }
+              direction: SORT_DIRECTION_DESC_NULLS_LAST
+            }
           }
         }
-        expressions {
-          literal {
-            string: "hiya"
-          }
-        }
+        count: 10
       }
     }
-    names: "show_string"
+    names: "grouping"
+    names: "# of Listeners"
   }
 }
 version {

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -51,7 +51,11 @@ SPARK_SUBSTRAIT_MAPPING = {
     'regexp_extract_all': ExtensionFunction(
         '/functions_string.yaml', 'regexp_match:str_binary_str', type_pb2.Type(
             list=type_pb2.Type.List(type=type_pb2.Type(string=type_pb2.Type.String(
-                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED)))))
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))))),
+    'substring': ExtensionFunction(
+        '/functions_string.yaml', 'substring:str_int_int', type_pb2.Type(
+            string=type_pb2.Type.String(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED)))
 }
 
 

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -55,6 +55,10 @@ SPARK_SUBSTRAIT_MAPPING = {
     'substring': ExtensionFunction(
         '/functions_string.yaml', 'substring:str_int_int', type_pb2.Type(
             string=type_pb2.Type.String(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'count': ExtensionFunction(
+        '/functions_aggregate_generic.yaml', 'count:any', type_pb2.Type(
+            i64=type_pb2.Type.I64(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED)))
 }
 

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -447,6 +447,11 @@ class SparkSubstraitConverter:
 
     def convert_show_string_relation(self, rel: spark_relations_pb2.ShowString) -> algebra_pb2.Rel:
         """Converts a show string relation into a Substrait project relation."""
+        if not self._conversion_options.implement_show_string:
+            result = self.convert_relation(rel.input)
+            self.update_field_references(rel.input.common.plan_id)
+            return result
+
         # TODO -- Implement using num_rows by wrapping the input in a fetch relation.
 
         # TODO -- Implement what happens if truncate is not set or less than two.

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -438,6 +438,10 @@ class SparkSubstraitConverter:
         # TODO -- Implement using num_rows, truncate, and vertical.
         result = self.convert_relation(rel.input)
         self.update_field_references(rel.input.common.plan_id)
+        # TODO -- Pull the columns from symbol.input_fields.
+        # TODO -- Use a project to output a single field with the table info in it.
+        # TODO -- Update the output field mapping to only contain that single row.
+        # TODO -- Name that output field 'show_string'.
         return result
 
     def convert_with_columns_relation(

--- a/src/gateway/demo/client_demo.py
+++ b/src/gateway/demo/client_demo.py
@@ -24,7 +24,6 @@ def execute_query(spark_session: SparkSession) -> None:
     # pylint: disable=singleton-comparison
     df_users2 = df_users \
         .filter(col('paid_for_service') == True) \
-        .withColumn('user_id', substring(col('user_id'), 5, 9)) \
         .sort(col('user_id')) \
         .limit(10)
 

--- a/src/gateway/demo/client_demo.py
+++ b/src/gateway/demo/client_demo.py
@@ -4,7 +4,7 @@ import atexit
 from pathlib import Path
 
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import col, desc
+from pyspark.sql.functions import col, desc, substring
 from pyspark.sql.pandas.types import from_arrow_schema
 
 from gateway.demo.mystream_database import create_mystream_database, delete_mystream_database
@@ -25,8 +25,10 @@ def execute_query() -> None:
         .parquet(users_location)
 
     # pylint: disable=singleton-comparison
+    #dataFrame.select(col("a"), substring_index(col("a"), ",", 1). as ("b"))
     df_users2 = df_users \
         .filter(col('paid_for_service') == True) \
+        .withColumn('user_id', substring(col('user_id'), 4, 9)) \
         .sort(desc('name')) \
         .limit(10)
 

--- a/src/gateway/demo/client_demo.py
+++ b/src/gateway/demo/client_demo.py
@@ -4,7 +4,7 @@ import atexit
 from pathlib import Path
 
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import col, desc, substring
+from pyspark.sql.functions import col, substring
 from pyspark.sql.pandas.types import from_arrow_schema
 
 from gateway.demo.mystream_database import create_mystream_database, delete_mystream_database
@@ -12,24 +12,20 @@ from gateway.demo.mystream_database import get_mystream_schema
 
 
 # pylint: disable=fixme
-def execute_query() -> None:
+def execute_query(spark_session: SparkSession) -> None:
     """Runs a single sample query against the gateway."""
-    # TODO -- Make this configurable.
-    spark = SparkSession.builder.remote('sc://localhost:50051').getOrCreate()
-
     users_location = str(Path('users.parquet').absolute())
     schema_users = get_mystream_schema('users')
 
-    df_users = spark.read.format('parquet') \
+    df_users = spark_session.read.format('parquet') \
         .schema(from_arrow_schema(schema_users)) \
         .parquet(users_location)
 
     # pylint: disable=singleton-comparison
-    #dataFrame.select(col("a"), substring_index(col("a"), ",", 1). as ("b"))
     df_users2 = df_users \
         .filter(col('paid_for_service') == True) \
-        .withColumn('user_id', substring(col('user_id'), 4, 9)) \
-        .sort(desc('name')) \
+        .withColumn('user_id', substring(col('user_id'), 5, 9)) \
+        .sort(col('user_id')) \
         .limit(10)
 
     df_users2.show()
@@ -38,4 +34,7 @@ def execute_query() -> None:
 if __name__ == '__main__':
     atexit.register(delete_mystream_database)
     path = create_mystream_database()
-    execute_query()
+
+    # TODO -- Make this configurable.
+    spark = SparkSession.builder.remote('sc://localhost:50051').getOrCreate()
+    execute_query(spark)

--- a/src/gateway/demo/client_demo.py
+++ b/src/gateway/demo/client_demo.py
@@ -4,7 +4,7 @@ import atexit
 from pathlib import Path
 
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import col, substring
+from pyspark.sql.functions import col
 from pyspark.sql.pandas.types import from_arrow_schema
 
 from gateway.demo.mystream_database import create_mystream_database, delete_mystream_database

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -93,14 +93,17 @@ class SparkConnectService(pb2_grpc.SparkConnectServiceServicer):
         return pb2.ReleaseExecuteResponse()
 
 
-def serve():
+def serve(port: int, wait: bool = True):
     """Starts the SparkConnect to Substrait gateway server."""
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     pb2_grpc.add_SparkConnectServiceServicer_to_server(SparkConnectService(), server)
-    server.add_insecure_port('[::]:50051')
+    server.add_insecure_port(f'[::]:{port}')
     server.start()
-    server.wait_for_termination()
+    if wait:
+        server.wait_for_termination()
+    else:
+        return server
 
 
 if __name__ == '__main__':
-    serve()
+    serve(50051)

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -101,8 +101,8 @@ def serve(port: int, wait: bool = True):
     server.start()
     if wait:
         server.wait_for_termination()
-    else:
-        return server
+        return None
+    return server
 
 
 if __name__ == '__main__':

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -80,12 +80,13 @@ class SparkConnectService(pb2_grpc.SparkConnectServiceServicer):
         print("Interrupt")
         return pb2.InterruptResponse()
 
-    def ReattachExecute(self, request: pb2.ReattachExecuteRequest, context: grpc.RpcContext) -> \
-    Generator[pb2.ExecutePlanResponse, None, None]:
+    def ReattachExecute(
+            self, request: pb2.ReattachExecuteRequest, context: grpc.RpcContext) -> Generator[
+        pb2.ExecutePlanResponse, None, None]:
         print("ReattachExecute")
         yield pb2.ExecutePlanResponse(
-           session_id=request.session_id,
-           result_complete=pb2.ExecutePlanResponse.ResultComplete())
+            session_id=request.session_id,
+            result_complete=pb2.ExecutePlanResponse.ResultComplete())
 
     def ReleaseExecute(self, request, context):
         print("ReleaseExecute")

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -58,7 +58,8 @@ class SparkConnectService(pb2_grpc.SparkConnectServiceServicer):
         results = backend.execute(substrait, self._options.backend)
         print(f"  results are: {results}")
 
-        if not self._options.implement_show_string:
+        if not self._options.implement_show_string and request.plan.root.WhichOneof(
+                'rel_type') == 'show_string':
             yield pb2.ExecutePlanResponse(
                 session_id=request.session_id,
                 arrow_batch=pb2.ExecutePlanResponse.ArrowBatch(row_count=results.num_rows,

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -14,13 +14,9 @@ from gateway.converter.spark_to_substrait import SparkSubstraitConverter
 from gateway.adbc.backend import AdbcBackend
 
 
-def show_string(table: pyarrow.lib.Table) -> bytes:
-    """Converts a table into a byte serialized single row string column Arrow Table."""
-    results_str = str(table)
-    schema = pyarrow.schema([('show_string', pyarrow.string())])
-    array = pyarrow.array([results_str])
-    batch = pyarrow.RecordBatch.from_arrays([array], schema=schema)
-    result_table = pyarrow.Table.from_batches([batch])
+def batch_to_bytes(batch: pyarrow.RecordBatch, schema: pyarrow.Schema) -> bytes:
+    """Serializes a RecordBatch into a bytes."""
+    result_table = pyarrow.Table.from_batches(batches=[batch])
     buffer = io.BytesIO()
     stream = pyarrow.RecordBatchStreamWriter(buffer, schema)
     stream.write_table(result_table)
@@ -48,10 +44,11 @@ class SparkConnectService(pb2_grpc.SparkConnectServiceServicer):
         results = backend.execute(substrait, self._options.backend)
         print(f"  results are: {results}")
 
-        yield pb2.ExecutePlanResponse(
-            session_id=request.session_id,
-            arrow_batch=pb2.ExecutePlanResponse.ArrowBatch(row_count=results.num_rows,
-                                                           data=show_string(results)))
+        for batch in results.to_batches():
+            yield pb2.ExecutePlanResponse(session_id=request.session_id,
+                                          arrow_batch=pb2.ExecutePlanResponse.ArrowBatch(
+                                              row_count=batch.num_rows,
+                                              data=batch_to_bytes(batch, results.schema)))
         # TODO -- When spark 3.4.0 support is not required, yield a ResultComplete message here.
 
     def AnalyzePlan(self, request, context):

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -67,7 +67,8 @@ def schema_users():
     return get_mystream_schema('users')
 
 
-@pytest.fixture(scope='module', params=['spark', 'gateway-over-duckdb'])
+@pytest.fixture(scope='module',
+                params=['spark', pytest.param('gateway-over-duckdb', marks=pytest.mark.xfail)])
 def spark_session(request):
     """Provides spark sessions connecting to various backends."""
     match request.param:

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -30,7 +30,7 @@ def _create_gateway_session():
     spark = (
         SparkSession
         .builder
-        .remote('sc://localhost:50051')
+        .remote('sc://localhost:50052')
         .appName('gateway')
         .getOrCreate()
     )
@@ -67,13 +67,13 @@ def schema_users():
     return get_mystream_schema('users')
 
 
-@pytest.fixture(scope='module', params=['spark', 'gateway-over-duckdb:'])
+@pytest.fixture(scope='module', params=['spark', 'gateway-over-duckdb'])
 def spark_session(request):
     """Provides spark sessions connecting to various backends."""
     match request.param:
         case 'spark':
             session_generator = _create_local_spark_session()
-        case 'gateway-over-duckdb:':
+        case 'gateway-over-duckdb':
             session_generator = _create_gateway_session()
         case _:
             raise NotImplementedError(f'No such session implemented: {request.param}')
@@ -84,6 +84,6 @@ def spark_session(request):
 @pytest.fixture(scope='function')
 def users_dataframe(spark_session, schema_users, users_location):
     """Provides a ready to go dataframe over the users database."""
-    spark_session.read.format('parquet') \
+    return spark_session.read.format('parquet') \
         .schema(from_arrow_schema(schema_users)) \
         .parquet(users_location)

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test fixtures for pytest of the gateway server."""
+from pathlib import Path
+
+from pyspark.sql import SparkSession
+from pyspark.sql.pandas.types import from_arrow_schema
+import pytest
+
+from gateway.demo.mystream_database import create_mystream_database, delete_mystream_database
+from gateway.demo.mystream_database import get_mystream_schema
+from gateway.server import serve
+
+
+def _create_local_spark_session():
+    """Creates a local spark session for testing."""
+    spark = (
+        SparkSession
+        .builder
+        .master('local')
+        .appName('gateway')
+        .getOrCreate()
+    )
+    yield spark
+    print("stopping the local spark session")
+    spark.stop()
+
+
+def _create_gateway_session():
+    """Creates a local gateway session for testing."""
+    spark = (
+        SparkSession
+        .builder
+        .remote('sc://localhost:50051')
+        .appName('gateway')
+        .getOrCreate()
+    )
+    yield spark
+    print("stopping the gateway session")
+    spark.stop()
+
+
+@pytest.fixture(scope='session', autouse=True)
+def manage_database() -> None:
+    """Creates the mystream database for use throughout all the tests."""
+    create_mystream_database()
+    yield
+    delete_mystream_database()
+
+
+@pytest.fixture(scope='module', autouse=True)
+def gateway_server():
+    """Starts up a spark to substrait gateway service."""
+    server = serve(50052, wait=False)
+    yield
+    server.stop(None)
+
+
+@pytest.fixture(scope='session')
+def users_location():
+    """Provides the location of the users database."""
+    return str(Path('users.parquet').absolute())
+
+
+@pytest.fixture(scope='session')
+def schema_users():
+    """Provides the schema of the users database."""
+    return get_mystream_schema('users')
+
+
+@pytest.fixture(scope='module', params=['spark', 'gateway-over-duckdb:'])
+def spark_session(request):
+    """Provides spark sessions connecting to various backends."""
+    match request.param:
+        case 'spark':
+            session_generator = _create_local_spark_session()
+        case 'gateway-over-duckdb:':
+            session_generator = _create_gateway_session()
+        case _:
+            raise NotImplementedError(f'No such session implemented: {request.param}')
+    yield from session_generator
+
+# pylint: disable=redefined-outer-name
+@pytest.fixture(scope='function')
+def users_dataframe(spark_session, schema_users, users_location):
+    """Provides a ready to go dataframe over the users database."""
+    spark_session.read.format('parquet') \
+        .schema(from_arrow_schema(schema_users)) \
+        .parquet(users_location)

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -79,6 +79,7 @@ def spark_session(request):
             raise NotImplementedError(f'No such session implemented: {request.param}')
     yield from session_generator
 
+
 # pylint: disable=redefined-outer-name
 @pytest.fixture(scope='function')
 def users_dataframe(spark_session, schema_users, users_location):

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -17,6 +17,7 @@ def _create_local_spark_session():
         SparkSession
         .builder
         .master('local')
+        .config("spark.driver.bindAddress", "127.0.0.1")
         .appName('gateway')
         .getOrCreate()
     )
@@ -31,6 +32,7 @@ def _create_gateway_session():
         SparkSession
         .builder
         .remote('sc://localhost:50052')
+        .config("spark.driver.bindAddress", "127.0.0.1")
         .appName('gateway')
         .getOrCreate()
     )

--- a/src/gateway/tests/test_server.py
+++ b/src/gateway/tests/test_server.py
@@ -13,10 +13,24 @@ class TestDataFrameAPI:
         outcome = users_dataframe.filter(col('paid_for_service') == True).collect()
         assert len(outcome) == 29
 
+    def test_count(self, users_dataframe):
+        outcome = users_dataframe.count()
+        assert outcome == 100
+
     def test_with_column(self, users_dataframe, spark_session):
         expected = spark_session.createDataFrame(
             data=[('849118289', 'Brooke Jones', False)],
             schema=['user_id', 'name', 'paid_for_service'])
         outcome = users_dataframe.withColumn('user_id', substring(col('user_id'), 5, 9)).limit(
+            1).collect()
+        assertDataFrameEqual(outcome, expected)
+
+    def test_cast(self, users_dataframe, spark_session):
+        expected = spark_session.createDataFrame(
+            data=[(849, 'Brooke Jones', False)],
+            schema=['user_id', 'name', 'paid_for_service'])
+        outcome = users_dataframe.withColumn(
+            'user_id',
+            substring(col('user_id'), 5, 3).cast('integer')).limit(
             1).collect()
         assertDataFrameEqual(outcome, expected)

--- a/src/gateway/tests/test_server.py
+++ b/src/gateway/tests/test_server.py
@@ -13,6 +13,20 @@ class TestDataFrameAPI:
         outcome = users_dataframe.filter(col('paid_for_service') == True).collect()
         assert len(outcome) == 29
 
+    # pylint: disable=singleton-comparison
+    def test_filter_with_show(self, users_dataframe, capsys):
+        expected = '''+-------------+------------+----------------+
+|      user_id|        name|paid_for_service|
++-------------+------------+----------------+
+|user669344115|Joshua Brown|            true|
++-------------+------------+----------------+
+only showing top 1 row
+
+'''
+        users_dataframe.filter(col('paid_for_service') == True).show(1)
+        outcome = capsys.readouterr().out
+        assert outcome == expected
+
     def test_count(self, users_dataframe):
         outcome = users_dataframe.count()
         assert outcome == 100

--- a/src/gateway/tests/test_server.py
+++ b/src/gateway/tests/test_server.py
@@ -1,11 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the Spark to Substrait Gateway server."""
-from pyspark.sql.functions import col
+from pyspark.sql.functions import col, substring
+from pyspark.testing import assertDataFrameEqual
 
 
-# pylint: disable=missing-function-docstring,too-few-public-methods
+# pylint: disable=missing-function-docstring
 class TestDataFrameAPI:
     """Tests of the dataframe side of SparkConnect."""
+
     # pylint: disable=singleton-comparison
     def test_filter(self, users_dataframe):
-        users_dataframe.filter(col('paid_for_service') == True)
+        outcome = users_dataframe.filter(col('paid_for_service') == True).collect()
+        assert len(outcome) == 29
+
+    def test_with_column(self, users_dataframe, spark_session):
+        expected = spark_session.createDataFrame(
+            data=[('849118289', 'Brooke Jones', False)],
+            schema=['user_id', 'name', 'paid_for_service'])
+        outcome = users_dataframe.withColumn('user_id', substring(col('user_id'), 5, 9)).limit(
+            1).collect()
+        assertDataFrameEqual(outcome, expected)

--- a/src/gateway/tests/test_server.py
+++ b/src/gateway/tests/test_server.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the Spark to Substrait Gateway server."""
-import pytest
 from pyspark.sql.functions import col
 
 
-class TestStuff:
+# pylint: disable=missing-function-docstring,too-few-public-methods
+class TestDataFrameAPI:
+    """Tests of the dataframe side of SparkConnect."""
     # pylint: disable=singleton-comparison
-    def test_filter(self, spark_session, users_dataframe):
+    def test_filter(self, users_dataframe):
         users_dataframe.filter(col('paid_for_service') == True)

--- a/src/gateway/tests/test_server.py
+++ b/src/gateway/tests/test_server.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Spark to Substrait Gateway server."""
+import pytest
+from pyspark.sql.functions import col
+
+
+class TestStuff:
+    # pylint: disable=singleton-comparison
+    def test_filter(self, spark_session, users_dataframe):
+        users_dataframe.filter(col('paid_for_service') == True)


### PR DESCRIPTION
This PR adds initial testing support where both Spark and the gateway (with whatever backends
are configured) are tested side by side (ensuring that the resulting plan and backend evaluate
the results identically).

Also:

- Begins the work on implementing show_string as an effective subplan of relations.
- Properly returns multiple messages where needed.
- Adds support for cast using a string argument.
- Also adds the substring and count functions to the Spark→Substrait mapping.
- Removes datafusion support due to package dependency issues to be returned later.
