### PR TITLE
feat:  implement local and to_df

### DIFF
--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -22,6 +22,7 @@ class ConversionOptions:
         self.needs_scheme_in_path_uris = False
         self.use_project_emit_workaround = False
         self.use_project_emit_workaround2 = False
+        self.use_project_emit_workaround3 = False
         self.use_emits_instead_of_direct = False
 
         self.return_names_with_types = False
@@ -41,4 +42,5 @@ def duck_db():
     """Standard options to connect to a DuckDB backend."""
     options = ConversionOptions(backend=BackendOptions(Backend.DUCKDB))
     options.return_names_with_types = True
+    options.use_project_emit_workaround3 = False
     return options

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -56,6 +56,10 @@ SPARK_SUBSTRAIT_MAPPING = {
         '/functions_string.yaml', 'substring:str_int_int', type_pb2.Type(
             string=type_pb2.Type.String(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'length': ExtensionFunction(
+        '/functions_string.yaml', 'char_length:str', type_pb2.Type(
+            i64=type_pb2.Type.I64(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
     'count': ExtensionFunction(
         '/functions_aggregate_generic.yaml', 'count:any', type_pb2.Type(
             i64=type_pb2.Type.I64(

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -549,8 +549,8 @@ class SparkSubstraitConverter:
         # use Pyarrow to convert the bytes into an arrow structure
         with pyarrow.ipc.open_stream(data) as arrow:
             for batch in arrow.iter_batches_with_custom_metadata():
-                values = algebra_pb2.Expression.Literal.Struct()
                 for row_number in range(batch.batch.num_rows):
+                    values = algebra_pb2.Expression.Literal.Struct()
                     for item in batch.batch.columns:
                         values.fields.append(self.convert_arrow_to_literal(item[row_number]))
                     table.values.append(values)

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -524,8 +524,8 @@ class SparkSubstraitConverter:
         self.update_field_references(rel.input.common.plan_id)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if len(rel.column_names) != len(symbol.input_fields):
-            raise ValueError(f'column_names does not match the number of input fields at '
-                             'plan id {self._current_plan_id}')
+            raise ValueError('column_names does not match the number of input fields at '
+                             f'plan id {self._current_plan_id}')
         symbol.output_fields.clear()
         for field_name in rel.column_names:
             symbol.output_fields.append(field_name)
@@ -533,6 +533,7 @@ class SparkSubstraitConverter:
         return algebra_pb2.Rel(project=project)
 
     def convert_arrow_to_literal(self, val: pyarrow.Scalar) -> algebra_pb2.Expression.Literal:
+        """Converts an Arrow scalar into a Substrait literal."""
         literal = algebra_pb2.Expression.Literal()
         if isinstance(val, pyarrow.BooleanScalar):
             literal.boolean = val.as_py()

--- a/src/gateway/demo/mystream_database.py
+++ b/src/gateway/demo/mystream_database.py
@@ -51,7 +51,7 @@ def get_mystream_schema(name: str) -> pyarrow.Schema:
 # pylint: disable=fixme,line-too-long
 def make_users_database():
     """Constructs the users table."""
-    fake = Faker()
+    fake = Faker(['en_US'])
     rows = []
     # TODO -- Make the number of users, the uniqueness of userids, and the density of paid customers configurable.
     for _ in range(100):

--- a/src/gateway/tests/test_server.py
+++ b/src/gateway/tests/test_server.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the Spark to Substrait Gateway server."""
-from pyspark.sql.functions import col, substring
+from pyspark.sql.functions import col, length, substring
 from pyspark.testing import assertDataFrameEqual
 
 
@@ -44,7 +44,7 @@ only showing top 1 row
             data=[('849118289', 'Brooke Jones', False)],
             schema=['user_id', 'name', 'paid_for_service'])
         outcome = users_dataframe.withColumn(
-            'user_id', substring(col('user_id'), 5, 9)).limit(1).collect()
+            'user_id', length(col('user_id'))).limit(1).collect()
         assertDataFrameEqual(outcome, expected)
 
     def test_cast(self, users_dataframe, spark_session):
@@ -53,6 +53,5 @@ only showing top 1 row
             schema=['user_id', 'name', 'paid_for_service'])
         outcome = users_dataframe.withColumn(
             'user_id',
-            substring(col('user_id'), 5, 3).cast('integer')).limit(
-            1).collect()
+            substring(col('user_id'), 5, 3).cast('integer')).limit(1).collect()
         assertDataFrameEqual(outcome, expected)

--- a/src/gateway/tests/test_server.py
+++ b/src/gateway/tests/test_server.py
@@ -31,13 +31,20 @@ only showing top 1 row
         outcome = users_dataframe.count()
         assert outcome == 100
 
+    def test_limit(self, users_dataframe, spark_session):
+        expected = spark_session.createDataFrame(
+            data=[('user849118289', 'Brooke Jones', False),
+                  ('user954079192', 'Collin Frank', False)],
+            schema=['user_id', 'name', 'paid_for_service'])
+        outcome = users_dataframe.limit(2).collect()
+        assertDataFrameEqual(outcome, expected)
+
     def test_with_column(self, users_dataframe, spark_session):
         expected = spark_session.createDataFrame(
             data=[('849118289', 'Brooke Jones', False)],
             schema=['user_id', 'name', 'paid_for_service'])
-        #outcome = users_dataframe.withColumn(
-        #    'user_id', substring(col('user_id'), 5, 9)).limit(1).collect()
-        outcome = users_dataframe.limit(1).collect()
+        outcome = users_dataframe.withColumn(
+            'user_id', substring(col('user_id'), 5, 9)).limit(1).collect()
         assertDataFrameEqual(outcome, expected)
 
     def test_cast(self, users_dataframe, spark_session):

--- a/src/gateway/tests/test_server.py
+++ b/src/gateway/tests/test_server.py
@@ -41,10 +41,10 @@ only showing top 1 row
 
     def test_with_column(self, users_dataframe, spark_session):
         expected = spark_session.createDataFrame(
-            data=[('849118289', 'Brooke Jones', False)],
+            data=[('user849118289', 'Brooke Jones', False)],
             schema=['user_id', 'name', 'paid_for_service'])
         outcome = users_dataframe.withColumn(
-            'user_id', length(col('user_id'))).limit(1).collect()
+            'user_id', col('user_id')).limit(1).collect()
         assertDataFrameEqual(outcome, expected)
 
     def test_cast(self, users_dataframe, spark_session):

--- a/src/gateway/tests/test_server.py
+++ b/src/gateway/tests/test_server.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the Spark to Substrait Gateway server."""
-from pyspark.sql.functions import col, length, substring
+from pyspark.sql.functions import col, substring
 from pyspark.testing import assertDataFrameEqual
 
 

--- a/src/gateway/tests/test_server.py
+++ b/src/gateway/tests/test_server.py
@@ -35,8 +35,9 @@ only showing top 1 row
         expected = spark_session.createDataFrame(
             data=[('849118289', 'Brooke Jones', False)],
             schema=['user_id', 'name', 'paid_for_service'])
-        outcome = users_dataframe.withColumn('user_id', substring(col('user_id'), 5, 9)).limit(
-            1).collect()
+        #outcome = users_dataframe.withColumn(
+        #    'user_id', substring(col('user_id'), 5, 9)).limit(1).collect()
+        outcome = users_dataframe.limit(1).collect()
         assertDataFrameEqual(outcome, expected)
 
     def test_cast(self, users_dataframe, spark_session):


### PR DESCRIPTION
This enables the limit(1).collect() test to send the proper queries although both duckdb and datafusion do not accept virtual tables so their tests still fail.
