### PR TITLE
feat: implements show_string using relations

### DIFF
--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -27,7 +27,7 @@ class ConversionOptions:
 
         self.return_names_with_types = False
 
-        self.implement_show_string = False
+        self.implement_show_string = True
 
         self.backend = backend
 

--- a/src/gateway/converter/label_relations.py
+++ b/src/gateway/converter/label_relations.py
@@ -55,7 +55,7 @@ def get_common_section(rel: algebra_pb2.Rel) -> algebra_pb2.RelCommon:
             result = rel.expand.common
         case _:
             raise NotImplementedError('Finding the common section for type '
-                                      f'{rel.WhichOneof('rel_type')} is not implemented')
+                                      f'{rel.WhichOneof("rel_type")} is not implemented')
     return result
 
 

--- a/src/gateway/converter/simplify_casts.py
+++ b/src/gateway/converter/simplify_casts.py
@@ -60,7 +60,7 @@ class SimplifyCasts(SubstraitPlanVisitor):
                 return rel.extension_single.input
             case _:
                 raise NotImplementedError('Finding single inputs of relations with type '
-                                          f'{rel.WhichOneof('rel_type')} are not implemented')
+                                          f'{rel.WhichOneof("rel_type")} are not implemented')
 
     @staticmethod
     def replace_single_input(rel: algebra_pb2.Rel, new_input: algebra_pb2.Rel):
@@ -80,7 +80,7 @@ class SimplifyCasts(SubstraitPlanVisitor):
                 rel.extension_single.input.CopyFrom(new_input)
             case _:
                 raise NotImplementedError('Modifying inputs of relations with type '
-                                          f'{rel.WhichOneof('rel_type')} are not implemented')
+                                          f'{rel.WhichOneof("rel_type")} are not implemented')
 
     def update_field_references(self, plan_id: int) -> None:
         """Uses the field references using the specified portion of the plan."""

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -64,6 +64,18 @@ SPARK_SUBSTRAIT_MAPPING = {
         '/functions_aggregate.yaml', 'max:i64', type_pb2.Type(
             i64=type_pb2.Type.I64(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'concat': ExtensionFunction(
+        '/functions_string.yaml', 'concat:str_str', type_pb2.Type(
+            string=type_pb2.Type.String(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'repeat': ExtensionFunction(
+        '/functions_string.yaml', 'repeat:str_i64', type_pb2.Type(
+            string=type_pb2.Type.String(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'rpad': ExtensionFunction(
+        '/functions_string.yaml', 'rpad:str_i64_str', type_pb2.Type(
+            string=type_pb2.Type.String(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
     'count': ExtensionFunction(
         '/functions_aggregate_generic.yaml', 'count:any', type_pb2.Type(
             i64=type_pb2.Type.I64(

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -40,6 +40,14 @@ SPARK_SUBSTRAIT_MAPPING = {
         '/functions_comparison.yaml', 'equal:str_str', type_pb2.Type(
             bool=type_pb2.Type.Boolean(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    '>=': ExtensionFunction(
+        '/functions_comparison.yaml', 'gte:str_str', type_pb2.Type(
+            bool=type_pb2.Type.Boolean(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    '-': ExtensionFunction(
+        '/functions_arithmetic.yaml', 'subtract:i64_i64', type_pb2.Type(
+            i64=type_pb2.Type.I64(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
     'array_contains': ExtensionFunction(
         '/functions_set.yaml', 'index_in:str_list<str>', type_pb2.Type(
             bool=type_pb2.Type.Boolean(

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -64,12 +64,28 @@ SPARK_SUBSTRAIT_MAPPING = {
         '/functions_aggregate.yaml', 'max:i64', type_pb2.Type(
             i64=type_pb2.Type.I64(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'string_agg': ExtensionFunction(
+        '/functions_string.yaml', 'string_agg:str', type_pb2.Type(
+            string=type_pb2.Type.String(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'least': ExtensionFunction(
+        '/functions_comparison.yaml', 'least:i64', type_pb2.Type(
+            i64=type_pb2.Type.I64(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'greatest': ExtensionFunction(
+        '/functions_comparison.yaml', 'greatest:i64', type_pb2.Type(
+            i64=type_pb2.Type.I64(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
     'concat': ExtensionFunction(
         '/functions_string.yaml', 'concat:str_str', type_pb2.Type(
             string=type_pb2.Type.String(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
     'repeat': ExtensionFunction(
         '/functions_string.yaml', 'repeat:str_i64', type_pb2.Type(
+            string=type_pb2.Type.String(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'lpad': ExtensionFunction(
+        '/functions_string.yaml', 'lpad:str_i64_str', type_pb2.Type(
             string=type_pb2.Type.String(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
     'rpad': ExtensionFunction(

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -44,6 +44,10 @@ SPARK_SUBSTRAIT_MAPPING = {
         '/functions_comparison.yaml', 'gte:str_str', type_pb2.Type(
             bool=type_pb2.Type.Boolean(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    '>': ExtensionFunction(
+        '/functions_comparison.yaml', 'gt:str_str', type_pb2.Type(
+            bool=type_pb2.Type.Boolean(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
     '-': ExtensionFunction(
         '/functions_arithmetic.yaml', 'subtract:i64_i64', type_pb2.Type(
             i64=type_pb2.Type.I64(

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -60,6 +60,10 @@ SPARK_SUBSTRAIT_MAPPING = {
         '/functions_string.yaml', 'char_length:str', type_pb2.Type(
             i64=type_pb2.Type.I64(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'max': ExtensionFunction(
+        '/functions_aggregate.yaml', 'max:i64', type_pb2.Type(
+            i64=type_pb2.Type.I64(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
     'count': ExtensionFunction(
         '/functions_aggregate_generic.yaml', 'count:any', type_pb2.Type(
             i64=type_pb2.Type.I64(

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -542,12 +542,14 @@ class SparkSubstraitConverter:
 
         project2 = project_relation(aggregate1, [
             concat(concat_func,
-                   cast(field_reference(0), string_type()),
-                   string_literal('  '),
-                   cast(field_reference(1), string_type()),
-                   string_literal('  '),
-                   cast(field_reference(2), string_type()),
-                   )
+                   [string_literal(field_name) for field_name in symbol.input_fields] + [
+                       string_literal('  '),
+                       cast(field_reference(0), string_type()),
+                       string_literal('  '),
+                       cast(field_reference(1), string_type()),
+                       string_literal('  '),
+                       cast(field_reference(2), string_type()),
+                   ])
         ])
 
         """

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -18,7 +18,7 @@ from gateway.converter.conversion_options import ConversionOptions
 from gateway.converter.spark_functions import ExtensionFunction, lookup_spark_function
 from gateway.converter.substrait_builder import field_reference, cast, string_type, \
     project_relation, strlen, concat, fetch_relation, join_relation, aggregate_relation, \
-    max_function
+    max_function, string_literal
 from gateway.converter.symbol_table import SymbolTable, PlanMetadata
 
 
@@ -543,9 +543,9 @@ class SparkSubstraitConverter:
         project2 = project_relation(aggregate1, [
             concat(concat_func,
                    cast(field_reference(0), string_type()),
-                   algebra_pb2.Expression(literal=self.convert_string_literal('  ')),
+                   string_literal('  '),
                    cast(field_reference(1), string_type()),
-                   algebra_pb2.Expression(literal=self.convert_string_literal('  ')),
+                   string_literal('  '),
                    cast(field_reference(2), string_type()),
                    )
         ])

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -17,7 +17,8 @@ from substrait.gen.proto.extensions import extensions_pb2
 from gateway.converter.conversion_options import ConversionOptions
 from gateway.converter.spark_functions import ExtensionFunction, lookup_spark_function
 from gateway.converter.substrait_builder import field_reference, cast, string_type, \
-    project_relation, strlen, concat, fetch_relation, join_relation, aggregate_relation
+    project_relation, strlen, concat, fetch_relation, join_relation, aggregate_relation, \
+    max_function
 from gateway.converter.symbol_table import SymbolTable, PlanMetadata
 
 
@@ -536,11 +537,7 @@ class SparkSubstraitConverter:
         aggregate1 = aggregate_relation(
             project1,
             measures=[
-                algebra_pb2.AggregateFunction(
-                    function_reference=max_func.anchor,
-                    output_type=max_func.output_type,
-                    arguments=[algebra_pb2.FunctionArgument(
-                        value=field_reference(column_number))])
+                max_function(max_func, column_number)
                 for column_number in range(len(symbol.input_fields))])
 
         project2 = project_relation(aggregate1, [

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -20,7 +20,7 @@ from gateway.converter.substrait_builder import field_reference, cast_operation,
     project_relation, strlen, concat, fetch_relation, join_relation, aggregate_relation, \
     max_agg_function, string_literal, flatten, repeat_function, \
     least_function, greatest_function, bigint_literal, lpad_function, string_concat_agg_function, \
-    if_then_else_operation, greater_or_equal_function, minus_function
+    if_then_else_operation, greater_function, minus_function
 from gateway.converter.symbol_table import SymbolTable
 
 
@@ -509,7 +509,7 @@ class SparkSubstraitConverter:
         lpad_func = self.lookup_function_by_name('lpad')
         least_func = self.lookup_function_by_name('least')
         greatest_func = self.lookup_function_by_name('greatest')
-        greater_or_equal_func = self.lookup_function_by_name('>=')
+        greater_func = self.lookup_function_by_name('>')
         minus_func = self.lookup_function_by_name('-')
 
         # Get the input and restrict it to the number of requested rows if necessary.
@@ -556,14 +556,13 @@ class SparkSubstraitConverter:
         def field_body_fragment(field_number: int) -> List[algebra_pb2.Expression]:
             return [string_literal('|'),
                     if_then_else_operation(
-                        greater_or_equal_function(greater_or_equal_func,
-                                                  strlen(strlen_func,
-                                                         cast_operation(
-                                                             field_reference(field_number),
-                                                             string_type())),
-                                                  minus_function(minus_func, field_reference(
-                                                      field_number + len(symbol.input_fields)),
-                                                                 bigint_literal(3))),
+                        greater_function(greater_func,
+                                         strlen(strlen_func,
+                                                cast_operation(
+                                                    field_reference(field_number),
+                                                    string_type())),
+                                         field_reference(
+                                             field_number + len(symbol.input_fields))),
                         concat(concat_func,
                                [lpad_function(lpad_func, field_reference(field_number),
                                               minus_function(minus_func, field_reference(

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -137,7 +137,7 @@ class SparkSubstraitConverter:
                 result = algebra_pb2.Expression.Literal()
             case _:
                 raise NotImplementedError(
-                    f'Unexpected literal type: {literal.WhichOneof('literal_type')}')
+                    f'Unexpected literal type: {literal.WhichOneof("literal_type")}')
         return algebra_pb2.Expression(literal=result)
 
     def convert_unresolved_attribute(
@@ -215,7 +215,7 @@ class SparkSubstraitConverter:
                 cast_rel.type.CopyFrom(self.convert_type_str(cast.type_str))
             case _:
                 raise NotImplementedError(
-                    f'unknown cast_to_type {cast.WhichOneof('cast_to_type')}'
+                    f'unknown cast_to_type {cast.WhichOneof("cast_to_type")}'
                 )
         return algebra_pb2.Expression(cast=cast_rel)
 
@@ -609,15 +609,18 @@ class SparkSubstraitConverter:
                    ),
         ])
 
+        # Merge all of the rows of the result body into a single string.
         aggregate2 = aggregate_relation(project3, measures=[
             string_concat_agg_function(string_concat_func, 0)])
 
+        # Create one row with the header, the body, and the footer in it.
         join2 = join_relation(project2, aggregate2)
 
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         symbol.output_fields.clear()
         symbol.output_fields.append('show_string')
 
+        # Combine the header, body, and footer into the final result.
         project4 = project_relation(join2, [
             concat(concat_func, [
                 field_reference(0),

--- a/src/gateway/converter/spark_to_substrait_test.py
+++ b/src/gateway/converter/spark_to_substrait_test.py
@@ -41,7 +41,9 @@ def test_plan_conversion(request, path):
         splan_prototext = file.read()
     substrait_plan = text_format.Parse(splan_prototext, plan_pb2.Plan())
 
-    convert = SparkSubstraitConverter(duck_db())
+    options = duck_db()
+    options.implement_show_string = False
+    convert = SparkSubstraitConverter(options)
     substrait = convert.convert_plan(spark_plan)
 
     if request.config.getoption('rebuild_goldens'):

--- a/src/gateway/converter/substrait_builder.py
+++ b/src/gateway/converter/substrait_builder.py
@@ -24,21 +24,18 @@ def project_relation(input_relation: algebra_pb2.Rel,
 
 
 # pylint: disable=fixme
-def aggregate_relation(input_relation: algebra_pb2.Rel, groupings: List[algebra_pb2.Expression],
+def aggregate_relation(input_relation: algebra_pb2.Rel,
                        measures: List[algebra_pb2.AggregateFunction]) -> algebra_pb2.Rel:
     """Constructs a Substrait aggregate plan node."""
     aggregate = algebra_pb2.Rel(
         aggregate=algebra_pb2.AggregateRel(
             common=algebra_pb2.RelCommon(emit=algebra_pb2.RelCommon.Emit(
-                output_mapping=[range(len(groupings) + len(measures))])),
+                output_mapping=range(len(measures)))),
             input=input_relation))
-    # TODO -- Support groupings with more than one expression in them.
-    for group in groupings:
-        aggregate.aggregate.groupings.append(
-            algebra_pb2.AggregateRel.Grouping(grouping_expressions=[group]))
+    # TODO -- Add support for groupings.
     for measure in measures:
         aggregate.aggregate.measures.append(
-            algebra_pb2.AggregateRel.MeasureFunction(measure=measure))
+            algebra_pb2.AggregateRel.Measure(measure=measure))
     return aggregate
 
 
@@ -86,6 +83,15 @@ def field_reference(field_number: int) -> algebra_pb2.Expression:
             direct_reference=algebra_pb2.Expression.ReferenceSegment(
                 struct_field=algebra_pb2.Expression.ReferenceSegment.StructField(
                     field=field_number))))
+
+
+def max(function_info: ExtensionFunction,
+        field_number: int) -> algebra_pb2.AggregateFunction:
+    """Constructs a Substrait concat expression."""
+    return algebra_pb2.Expression.AggregateFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=field_reference(field_number))])
 
 
 def string_type(required: bool = True) -> type_pb2.Type:

--- a/src/gateway/converter/substrait_builder.py
+++ b/src/gateway/converter/substrait_builder.py
@@ -83,6 +83,17 @@ def cast_operation(expression: algebra_pb2.Expression,
     )
 
 
+def if_then_else_operation(if_expr: algebra_pb2.Expression, then_expr: algebra_pb2.Expression,
+                           else_expr: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a simplistic Substrait if-then-else expression."""
+    return algebra_pb2.Expression(
+        if_then=algebra_pb2.Expression.IfThen(
+            **{'ifs': [
+                algebra_pb2.Expression.IfThen.IfClause(**{'if': if_expr, 'then': then_expr})],
+                'else': else_expr})
+    )
+
+
 def field_reference(field_number: int) -> algebra_pb2.Expression:
     """Constructs a Substrait field reference expression."""
     return algebra_pb2.Expression(
@@ -103,7 +114,7 @@ def max_agg_function(function_info: ExtensionFunction,
 
 
 def string_concat_agg_function(function_info: ExtensionFunction,
-                        field_number: int) -> algebra_pb2.AggregateFunction:
+                               field_number: int) -> algebra_pb2.AggregateFunction:
     """Constructs a Substrait string concat aggregate function."""
     return algebra_pb2.AggregateFunction(
         function_reference=function_info.anchor,
@@ -135,8 +146,33 @@ def greatest_function(function_info: ExtensionFunction,
                    algebra_pb2.FunctionArgument(value=expr2)]))
 
 
+def greater_or_equal_function(function_info: ExtensionFunction,
+                              expr1: algebra_pb2.Expression,
+                              expr2: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a Substrait min expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=expr1),
+                   algebra_pb2.FunctionArgument(value=expr2)]))
+
+
+def minus_function(function_info: ExtensionFunction,
+                   expr1: algebra_pb2.Expression,
+                   expr2: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a Substrait min expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=expr1),
+                   algebra_pb2.FunctionArgument(value=expr2)]))
+
+
 def repeat_function(function_info: ExtensionFunction,
-                    string: str, count: algebra_pb2.Expression) -> algebra_pb2.AggregateFunction:
+                    string: str,
+                    count: algebra_pb2.Expression) -> algebra_pb2.AggregateFunction:
     """Constructs a Substrait concat expression."""
     return algebra_pb2.Expression(scalar_function=
     algebra_pb2.Expression.ScalarFunction(
@@ -154,10 +190,11 @@ def lpad_function(function_info: ExtensionFunction,
     algebra_pb2.Expression.ScalarFunction(
         function_reference=function_info.anchor,
         output_type=function_info.output_type,
-        arguments=[algebra_pb2.FunctionArgument(value=cast_operation(expression, varchar_type())),
-                   algebra_pb2.FunctionArgument(value=cast_operation(count, integer_type())),
-                   algebra_pb2.FunctionArgument(
-                       value=cast_operation(string_literal(pad_string), varchar_type()))]))
+        arguments=[
+            algebra_pb2.FunctionArgument(value=cast_operation(expression, varchar_type())),
+            algebra_pb2.FunctionArgument(value=cast_operation(count, integer_type())),
+            algebra_pb2.FunctionArgument(
+                value=cast_operation(string_literal(pad_string), varchar_type()))]))
 
 
 def rpad_function(function_info: ExtensionFunction,
@@ -168,10 +205,11 @@ def rpad_function(function_info: ExtensionFunction,
     algebra_pb2.Expression.ScalarFunction(
         function_reference=function_info.anchor,
         output_type=function_info.output_type,
-        arguments=[algebra_pb2.FunctionArgument(value=cast_operation(expression, varchar_type())),
-                   algebra_pb2.FunctionArgument(value=cast_operation(count, integer_type())),
-                   algebra_pb2.FunctionArgument(
-                       value=cast_operation(string_literal(pad_string), varchar_type()))]))
+        arguments=[
+            algebra_pb2.FunctionArgument(value=cast_operation(expression, varchar_type())),
+            algebra_pb2.FunctionArgument(value=cast_operation(count, integer_type())),
+            algebra_pb2.FunctionArgument(
+                value=cast_operation(string_literal(pad_string), varchar_type()))]))
 
 
 def string_literal(val: str) -> algebra_pb2.Expression:

--- a/src/gateway/converter/substrait_builder.py
+++ b/src/gateway/converter/substrait_builder.py
@@ -85,10 +85,10 @@ def field_reference(field_number: int) -> algebra_pb2.Expression:
                     field=field_number))))
 
 
-def max(function_info: ExtensionFunction,
+def max_function(function_info: ExtensionFunction,
         field_number: int) -> algebra_pb2.AggregateFunction:
     """Constructs a Substrait concat expression."""
-    return algebra_pb2.Expression.AggregateFunction(
+    return algebra_pb2.AggregateFunction(
         function_reference=function_info.anchor,
         output_type=function_info.output_type,
         arguments=[algebra_pb2.FunctionArgument(value=field_reference(field_number))])

--- a/src/gateway/converter/substrait_builder.py
+++ b/src/gateway/converter/substrait_builder.py
@@ -114,12 +114,14 @@ def max_agg_function(function_info: ExtensionFunction,
 
 
 def string_concat_agg_function(function_info: ExtensionFunction,
-                               field_number: int) -> algebra_pb2.AggregateFunction:
+                               field_number: int,
+                               separator: str = '') -> algebra_pb2.AggregateFunction:
     """Constructs a Substrait string concat aggregate function."""
     return algebra_pb2.AggregateFunction(
         function_reference=function_info.anchor,
         output_type=function_info.output_type,
-        arguments=[algebra_pb2.FunctionArgument(value=field_reference(field_number))])
+        arguments=[algebra_pb2.FunctionArgument(value=field_reference(field_number)),
+                   algebra_pb2.FunctionArgument(value=string_literal(separator))])
 
 
 def least_function(function_info: ExtensionFunction,
@@ -149,6 +151,18 @@ def greatest_function(function_info: ExtensionFunction,
 def greater_or_equal_function(function_info: ExtensionFunction,
                               expr1: algebra_pb2.Expression,
                               expr2: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a Substrait min expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=expr1),
+                   algebra_pb2.FunctionArgument(value=expr2)]))
+
+
+def greater_function(function_info: ExtensionFunction,
+                     expr1: algebra_pb2.Expression,
+                     expr2: algebra_pb2.Expression) -> algebra_pb2.Expression:
     """Constructs a Substrait min expression."""
     return algebra_pb2.Expression(scalar_function=
     algebra_pb2.Expression.ScalarFunction(

--- a/src/gateway/converter/substrait_builder.py
+++ b/src/gateway/converter/substrait_builder.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Convenience builder for constructing Substrait plans."""
+from typing import List
+
+from substrait.gen.proto import algebra_pb2, type_pb2
+
+from gateway.converter.spark_functions import ExtensionFunction
+
+
+def fetch(input_relation: algebra_pb2.Rel, num_rows: int) -> algebra_pb2.Rel:
+    """Constructs a Substrait fetch plan node."""
+    fetch = algebra_pb2.Rel(fetch=algebra_pb2.FetchRel(input=input_relation, count=num_rows))
+
+    return fetch
+
+
+def project_relation(input_relation: algebra_pb2.Rel,
+                     expressions: List[algebra_pb2.Expression]) -> algebra_pb2.Rel:
+    """Constructs a Substrait project plan node."""
+    return algebra_pb2.Rel(
+        project=algebra_pb2.ProjectRel(input=input_relation, expressions=expressions))
+
+
+# pylint: disable=fixme
+def aggregate(input_relation: algebra_pb2.Rel, groupings: List[algebra_pb2.Expression],
+              measures: List[algebra_pb2.AggregateFunction]) -> algebra_pb2.Rel:
+    """Constructs a Substrait aggregate plan node."""
+    aggregate = algebra_pb2.Rel(
+        aggregate=algebra_pb2.AggregateRel(
+            common=algebra_pb2.RelCommon(emit=algebra_pb2.RelCommon.Emit(
+                output_mapping=[range(len(groupings) + len(measures))])),
+            input=input_relation))
+    # TODO -- Support groupings with more than one expression in them.
+    for group in groupings:
+        aggregate.aggregate.groupings.append(
+            algebra_pb2.AggregateRel.Grouping(grouping_expressions=[group]))
+    for measure in measures:
+        aggregate.aggregate.measures.append(
+            algebra_pb2.AggregateRel.MeasureFunction(measure=measure))
+    return aggregate
+
+
+def join(left: algebra_pb2.Rel, right: algebra_pb2.Rel) -> algebra_pb2.Rel:
+    """Constructs a Substrait join plan node."""
+    return algebra_pb2.Rel(
+        join=algebra_pb2.JoinRel(common=algebra_pb2.RelCommon(), left=left, right=right,
+                                 expression=algebra_pb2.Expression(
+                                     literal=algebra_pb2.Expression.Literal(boolean=True)),
+                                 type=algebra_pb2.JoinRel.JoinType.JOIN_TYPE_INNER))
+
+
+def concat(function_info: ExtensionFunction,
+           *expressions: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a Substrait concat expression."""
+    return algebra_pb2.Expression(
+        scalar_function=algebra_pb2.Expression.ScalarFunction(
+            function_reference=function_info.anchor,
+            output_type=function_info.output_type,
+            arguments=[algebra_pb2.FunctionArgument(value=expression) for expression in expressions]
+        ))
+
+
+def strlen(function_info: ExtensionFunction,
+           expression: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a Substrait concat expression."""
+    return algebra_pb2.Expression(
+        scalar_function=algebra_pb2.Expression.ScalarFunction(
+            function_reference=function_info.anchor,
+            output_type=function_info.output_type,
+            arguments=[algebra_pb2.FunctionArgument(value=expression)]))
+
+
+def cast(expression: algebra_pb2.Expression, output_type: type_pb2.Type) -> algebra_pb2.Expression:
+    """Constructs a Substrait cast expression."""
+    return algebra_pb2.Expression(
+        cast=algebra_pb2.Expression.Cast(input=expression, type=output_type)
+    )
+
+
+def field_reference(field_number: int) -> algebra_pb2.Expression:
+    """Constructs a Substrait field reference expression."""
+    return algebra_pb2.Expression(
+        selection=algebra_pb2.Expression.FieldReference(
+            direct_reference=algebra_pb2.Expression.ReferenceSegment(
+                struct_field=algebra_pb2.Expression.ReferenceSegment.StructField(
+                    field=field_number))))
+
+
+def string_type(
+        required: type_pb2.Type.Nullability = type_pb2.Type.Nullability.NULLABILITY_REQUIRED) -> type_pb2.Type:
+    """Constructs a Substrait string type."""
+    return type_pb2.Type(
+        string=type_pb2.Type.String(
+            nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))

--- a/src/gateway/converter/substrait_builder.py
+++ b/src/gateway/converter/substrait_builder.py
@@ -49,7 +49,7 @@ def join_relation(left: algebra_pb2.Rel, right: algebra_pb2.Rel) -> algebra_pb2.
 
 
 def concat(function_info: ExtensionFunction,
-           *expressions: algebra_pb2.Expression) -> algebra_pb2.Expression:
+           expressions: List[algebra_pb2.Expression]) -> algebra_pb2.Expression:
     """Constructs a Substrait concat expression."""
     return algebra_pb2.Expression(
         scalar_function=algebra_pb2.Expression.ScalarFunction(

--- a/src/gateway/converter/substrait_builder.py
+++ b/src/gateway/converter/substrait_builder.py
@@ -86,12 +86,17 @@ def field_reference(field_number: int) -> algebra_pb2.Expression:
 
 
 def max_function(function_info: ExtensionFunction,
-        field_number: int) -> algebra_pb2.AggregateFunction:
+                 field_number: int) -> algebra_pb2.AggregateFunction:
     """Constructs a Substrait concat expression."""
     return algebra_pb2.AggregateFunction(
         function_reference=function_info.anchor,
         output_type=function_info.output_type,
         arguments=[algebra_pb2.FunctionArgument(value=field_reference(field_number))])
+
+
+def string_literal(val: str) -> algebra_pb2.Expression:
+    """Constructs a Substrait string literal expression."""
+    return algebra_pb2.Expression(literal=algebra_pb2.Expression.Literal(string=val))
 
 
 def string_type(required: bool = True) -> type_pb2.Type:

--- a/src/gateway/converter/substrait_builder.py
+++ b/src/gateway/converter/substrait_builder.py
@@ -7,7 +7,9 @@ from substrait.gen.proto import algebra_pb2, type_pb2
 from gateway.converter.spark_functions import ExtensionFunction
 
 
-def fetch(input_relation: algebra_pb2.Rel, num_rows: int) -> algebra_pb2.Rel:
+# pylint: disable=E1101
+
+def fetch_relation(input_relation: algebra_pb2.Rel, num_rows: int) -> algebra_pb2.Rel:
     """Constructs a Substrait fetch plan node."""
     fetch = algebra_pb2.Rel(fetch=algebra_pb2.FetchRel(input=input_relation, count=num_rows))
 
@@ -22,8 +24,8 @@ def project_relation(input_relation: algebra_pb2.Rel,
 
 
 # pylint: disable=fixme
-def aggregate(input_relation: algebra_pb2.Rel, groupings: List[algebra_pb2.Expression],
-              measures: List[algebra_pb2.AggregateFunction]) -> algebra_pb2.Rel:
+def aggregate_relation(input_relation: algebra_pb2.Rel, groupings: List[algebra_pb2.Expression],
+                       measures: List[algebra_pb2.AggregateFunction]) -> algebra_pb2.Rel:
     """Constructs a Substrait aggregate plan node."""
     aggregate = algebra_pb2.Rel(
         aggregate=algebra_pb2.AggregateRel(
@@ -40,7 +42,7 @@ def aggregate(input_relation: algebra_pb2.Rel, groupings: List[algebra_pb2.Expre
     return aggregate
 
 
-def join(left: algebra_pb2.Rel, right: algebra_pb2.Rel) -> algebra_pb2.Rel:
+def join_relation(left: algebra_pb2.Rel, right: algebra_pb2.Rel) -> algebra_pb2.Rel:
     """Constructs a Substrait join plan node."""
     return algebra_pb2.Rel(
         join=algebra_pb2.JoinRel(common=algebra_pb2.RelCommon(), left=left, right=right,
@@ -86,9 +88,10 @@ def field_reference(field_number: int) -> algebra_pb2.Expression:
                     field=field_number))))
 
 
-def string_type(
-        required: type_pb2.Type.Nullability = type_pb2.Type.Nullability.NULLABILITY_REQUIRED) -> type_pb2.Type:
+def string_type(required: bool = True) -> type_pb2.Type:
     """Constructs a Substrait string type."""
-    return type_pb2.Type(
-        string=type_pb2.Type.String(
-            nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))
+    if required:
+        nullability = type_pb2.Type.Nullability.NULLABILITY_REQUIRED
+    else:
+        nullability = type_pb2.Type.Nullability.NULLABILITY_NULLABLE
+    return type_pb2.Type(string=type_pb2.Type.String(nullability=nullability))

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -68,6 +68,7 @@ class SparkConnectService(pb2_grpc.SparkConnectServiceServicer):
         results = backend.execute(substrait, self._options.backend)
         _LOGGER.debug('  results are: %s', results)
 
+        # TODO -- Important:  Include the schema in the returned results.
         if not self._options.implement_show_string and request.plan.root.WhichOneof(
                 'rel_type') == 'show_string':
             yield pb2.ExecutePlanResponse(


### PR DESCRIPTION
While writing this is was evident that writing generated protobufs even with list comprehensions
were going to be nigh near impossible to read.  I introduced the start of a substrait_builder class
which allows for an easier way of constructing relations and generally allows for composability of
sections using functions.  It doesn't implement all functions, has some repetition that could be
eliminated (for instance how many methods do we need that take two expressions as arguments?),
and could be even cleaner if every function usage didn't need to pass in the function information.
However addressing those issues are beyond the scope of what we were trying to accomplish here.
The builder really belongs in substrait-python and doing so will require refactoring how functions
are converted from spark names into Substrait.  After that the other code already in
spark_to_substrait.py can be updated to use the builder which will also make it more readable.
