### PR TITLE
feat: use generic adbc driver to setup backend db

### DIFF
--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -34,6 +34,7 @@ TABLE_NAME = "my_table"
 
 
 def get_backend_driver(options: BackendOptions) -> tuple[str, str]:
+    """Gets the driver and entry point for the specified backend."""
     match options.backend:
         case Backend.DUCKDB:
             driver = duckdb.duckdb.__file__

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -55,13 +55,12 @@ def fetch_schema_with_adbc(file_path: str, ext: str, options: BackendOptions) ->
 
     driver, entry_point = get_backend_driver(options)
 
-    with dbapi.connect(driver=driver, entrypoint=entry_point) as conn:
-        with conn.cursor() as cur:
-            # TODO: Support multiple paths.
-            reader = pyarrow.parquet.ParquetFile(file_path)
-            cur.adbc_ingest(TABLE_NAME, reader.iter_batches(), mode="create")
-            schema = conn.adbc_get_table_schema(TABLE_NAME)
-            cur.execute(f"DROP TABLE {TABLE_NAME}")
+    with dbapi.connect(driver=driver, entrypoint=entry_point) as conn, conn.cursor() as cur:
+        # TODO: Support multiple paths.
+        reader = pyarrow.parquet.ParquetFile(file_path)
+        cur.adbc_ingest(TABLE_NAME, reader.iter_batches(), mode="create")
+        schema = conn.adbc_get_table_schema(TABLE_NAME)
+        cur.execute(f"DROP TABLE {TABLE_NAME}")
 
     return schema
 


### PR DESCRIPTION
Instead of using the duckdb_adbc_driver we now use the adbc_driver_manager
so that we can easily switch between different backends.