### PR TITLE
feat: separate passing DuckDB tests from xfailing ones

### DIFF
--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -82,10 +82,11 @@ def schema_users():
 
 @pytest.fixture(scope='session',
                 params=['spark',
-                        pytest.param('gateway-over-duckdb', marks=pytest.mark.xfail),
+                        'gateway-over-duckdb',
                         pytest.param('gateway-over-datafusion',
                                      marks=pytest.mark.xfail(
-                                         reason='Datafusion Substrait missing in CI'))])
+                                         reason='Datafusion Substrait missing in CI',
+                                         strict=True))])
 def source(request) -> str:
     """Provides the source (backend) to be used."""
     return request.param

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -85,8 +85,7 @@ def schema_users():
                         'gateway-over-duckdb',
                         pytest.param('gateway-over-datafusion',
                                      marks=pytest.mark.xfail(
-                                         reason='Datafusion Substrait missing in CI',
-                                         strict=True))])
+                                         reason='Datafusion Substrait missing in CI'))])
 def source(request) -> str:
     """Provides the source (backend) to be used."""
     return request.param

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -1,9 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the Spark to Substrait Gateway server."""
+import pytest
 from hamcrest import assert_that, equal_to
 from pyspark import Row
 from pyspark.sql.functions import col, substring
 from pyspark.testing import assertDataFrameEqual
+
+
+@pytest.fixture(autouse=True)
+def mark_tests_as_xfail(request):
+    """Marks a subset of tests as expected to be fail."""
+    source = request.getfixturevalue('source')
+    originalname = request.keywords.get('originalname', None)
+    if source == 'gateway-over-duckdb' and (originalname == 'test_with_column' or
+            originalname == 'test_cast'):
+        request.node.add_marker(pytest.xfail(reason='', strict=True))
 
 
 # pylint: disable=missing-function-docstring

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -8,13 +8,14 @@ from pyspark.testing import assertDataFrameEqual
 
 
 @pytest.fixture(autouse=True)
-def mark_tests_as_xfail(request):
+def mark_dataframe_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     source = request.getfixturevalue('source')
-    originalname = request.keywords.get('originalname', None)
+    originalname = request.keywords.node.originalname
     if source == 'gateway-over-duckdb' and (originalname == 'test_with_column' or
-            originalname == 'test_cast'):
-        request.node.add_marker(pytest.xfail(reason='', strict=True))
+                                            originalname == 'test_cast'):
+        request.node.add_marker(
+            pytest.mark.xfail(reason='DuckDB column binding error'))
 
 
 # pylint: disable=missing-function-docstring

--- a/src/gateway/tests/test_sql_api.py
+++ b/src/gateway/tests/test_sql_api.py
@@ -14,6 +14,16 @@ sql_test_case_paths = [f for f in sorted(test_case_directory.iterdir()) if f.suf
 sql_test_case_names = [p.stem for p in sql_test_case_paths]
 
 
+@pytest.fixture(autouse=True)
+def mark_tests_as_xfail(request):
+    """Marks a subset of tests as expected to be fail."""
+    source = request.getfixturevalue('source')
+    originalname = request.keywords.get('originalname', None)
+    if source == 'gateway-over-duckdb' and (originalname == 'test_with_column' or
+            originalname == 'test_cast'):
+        request.node.add_marker(pytest.xfail(reason='', strict=True))
+
+
 # pylint: disable=missing-function-docstring
 # ruff: noqa: E712
 class TestSqlAPI:

--- a/src/gateway/tests/test_sql_api.py
+++ b/src/gateway/tests/test_sql_api.py
@@ -18,10 +18,11 @@ sql_test_case_names = [p.stem for p in sql_test_case_paths]
 def mark_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     source = request.getfixturevalue('source')
-    originalname = request.keywords.get('originalname', None)
-    if source == 'gateway-over-duckdb' and (originalname == 'test_with_column' or
-            originalname == 'test_cast'):
-        request.node.add_marker(pytest.xfail(reason='', strict=True))
+    originalname = request.keywords.node.originalname
+    if source == 'gateway-over-duckdb' and originalname == 'test_tpch':
+        path = request.getfixturevalue('path')
+        if path.stem in ['02', '04', '15', '16', '17', '18', '20', '21', '22']:
+            request.node.add_marker(pytest.mark.xfail(reason='DuckDB needs Delim join'))
 
 
 # pylint: disable=missing-function-docstring

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -3,9 +3,18 @@
 import datetime
 
 import pyspark
+import pytest
 from pyspark import Row
 from pyspark.sql.functions import avg, col, count, countDistinct, desc, try_sum, when
 from pyspark.testing import assertDataFrameEqual
+
+@pytest.fixture(autouse=True)
+def mark_tests_as_xfail(request):
+    """Marks a subset of tests as expected to be fail."""
+    source = request.getfixturevalue('source')
+    originalname = request.keywords.get('originalname', None)
+    if source == 'gateway-over-duckdb' and originalname == 'test_query_01':
+        request.node.add_marker(pytest.xfail(reason='', strict=True))
 
 
 class TestTpchWithDataFrameAPI:

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -8,13 +8,26 @@ from pyspark import Row
 from pyspark.sql.functions import avg, col, count, countDistinct, desc, try_sum, when
 from pyspark.testing import assertDataFrameEqual
 
+
 @pytest.fixture(autouse=True)
 def mark_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     source = request.getfixturevalue('source')
-    originalname = request.keywords.get('originalname', None)
+    originalname = request.keywords.node.originalname
     if source == 'gateway-over-duckdb' and originalname == 'test_query_01':
-        request.node.add_marker(pytest.xfail(reason='', strict=True))
+        request.node.add_marker(pytest.mark.xfail(reason='date32[day] not handled'))
+    if source == 'gateway-over-duckdb' and originalname in [
+        'test_query_02', 'test_query_03', 'test_query_05', 'test_query_07', 'test_query_08',
+        'test_query_09', 'test_query_10', 'test_query_11', 'test_query_12', 'test_query_13',
+        'test_query_15', 'test_query_16', 'test_query_17', 'test_query_18', 'test_query_20',
+        'test_query_21', 'test_query_22']:
+        request.node.add_marker(pytest.mark.xfail(reason='AnalyzePlan not implemented'))
+    if source == 'gateway-over-duckdb' and originalname == 'test_query_04':
+        request.node.add_marker(pytest.mark.xfail(reason='deduplicate not implemented'))
+    if source == 'gateway-over-duckdb' and originalname in ['test_query_06', 'test_query_14']:
+        request.node.add_marker(pytest.mark.xfail(reason='subquery_alias not implemented'))
+    if source == 'gateway-over-duckdb' and originalname == 'test_query_19':
+        request.node.add_marker(pytest.mark.xfail(reason='project not implemented'))
 
 
 class TestTpchWithDataFrameAPI:


### PR DESCRIPTION
This should help prevent the passing tests from breaking during ongoing development.
