### PR TITLE
feat:  add format back to the register table method signature

### DIFF
--- a/src/gateway/backends/adbc_backend.py
+++ b/src/gateway/backends/adbc_backend.py
@@ -54,9 +54,9 @@ class AdbcBackend(Backend):
             res = cur.adbc_statement.execute_query()
             return _import(res[0]).read_all()
 
-    def register_table(self, name: str, path: Path, extension: str = 'parquet') -> None:
+    def register_table(self, name: str, path: Path, file_format: str = 'parquet') -> None:
         """Register the given table with the backend."""
-        file_paths = sorted(Path(path).glob(f'*.{extension}'))
+        file_paths = sorted(Path(path).glob(f'*.{file_format}'))
         if len(file_paths) > 0:
             # Sort the files because the later ones don't have enough data to construct a schema.
             file_paths = sorted([str(fp) for fp in file_paths])

--- a/src/gateway/backends/arrow_backend.py
+++ b/src/gateway/backends/arrow_backend.py
@@ -26,7 +26,7 @@ class ArrowBackend(Backend):
         reader = pa.substrait.run_query(plan_data, table_provider=self._provide_tables)
         return reader.read_all()
 
-    def register_table(self, name: str, path: Path) -> None:
+    def register_table(self, name: str, path: Path, file_format: str = 'parquet') -> None:
         """Register the given table with the backend."""
         self._registered_tables[name] = path
 

--- a/src/gateway/backends/backend.py
+++ b/src/gateway/backends/backend.py
@@ -31,7 +31,7 @@ class Backend:
         """Execute the given Substrait plan against Datafusion."""
         raise NotImplementedError()
 
-    def register_table(self, name: str, path: Path) -> None:
+    def register_table(self, name: str, path: Path, file_format: str = 'parquet') -> None:
         """Register the given table with the backend."""
         raise NotImplementedError()
 

--- a/src/gateway/backends/datafusion_backend.py
+++ b/src/gateway/backends/datafusion_backend.py
@@ -59,7 +59,7 @@ class DatafusionBackend(Backend):
             for table_name in registered_tables:
                 self._connection.deregister_table(table_name)
 
-    def register_table(self, name: str, path: Path) -> None:
+    def register_table(self, name: str, path: Path, file_format: str = 'parquet') -> None:
         """Register the given table with the backend."""
         files = Backend.expand_location(path)
         self._connection.register_parquet(name, files[0])

--- a/src/gateway/backends/duckdb_backend.py
+++ b/src/gateway/backends/duckdb_backend.py
@@ -44,7 +44,7 @@ class DuckDBBackend(Backend):
         df = query_result.df()
         return pa.Table.from_pandas(df=df)
 
-    def register_table(self, table_name: str, location: Path) -> None:
+    def register_table(self, table_name: str, location: Path, file_format: str = 'parquet') -> None:
         """Register the given table with the backend."""
         files = Backend.expand_location(location)
         if not files:

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -83,9 +83,8 @@ def schema_users():
 @pytest.fixture(scope='session',
                 params=['spark',
                         'gateway-over-duckdb',
-                        pytest.param('gateway-over-datafusion',
-                                     marks=pytest.mark.xfail(
-                                         reason='Datafusion Substrait missing in CI'))])
+                        'gateway-over-datafusion',
+                        ])
 def source(request) -> str:
     """Provides the source (backend) to be used."""
     return request.param

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -17,10 +17,10 @@ def mark_dataframe_tests_as_xfail(request):
                                             originalname == 'test_cast'):
         request.node.add_marker(
             pytest.mark.xfail(reason='DuckDB column binding error'))
-    if source == 'gateway-over-datafusion':
-        if originalname in ['test_data_source_schema', 'test_data_source_filter', 'test_table',
-                            'test_table_schema', 'test_table_filter']:
-            request.node.add_marker(pytest.mark.xfail(reason='Gateway internal iterating error'))
+    elif source == 'gateway-over-datafusion' and originalname in [
+        'test_data_source_schema', 'test_data_source_filter', 'test_table', 'test_table_schema',
+        'test_table_filter']:
+        request.node.add_marker(pytest.mark.xfail(reason='Gateway internal iterating error'))
 
 
 # pylint: disable=missing-function-docstring

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -17,10 +17,13 @@ def mark_dataframe_tests_as_xfail(request):
                                             originalname == 'test_cast'):
         request.node.add_marker(
             pytest.mark.xfail(reason='DuckDB column binding error'))
-    elif source == 'gateway-over-datafusion' and originalname in [
-        'test_data_source_schema', 'test_data_source_filter', 'test_table', 'test_table_schema',
-        'test_table_filter']:
-        request.node.add_marker(pytest.mark.xfail(reason='Gateway internal iterating error'))
+    elif source == 'gateway-over-datafusion':
+        if originalname in [
+            'test_data_source_schema', 'test_data_source_filter', 'test_table', 'test_table_schema',
+            'test_table_filter']:
+            request.node.add_marker(pytest.mark.xfail(reason='Gateway internal iterating error'))
+        else:
+            pytest.importorskip("datafusion.substrait")
 
 
 # pylint: disable=missing-function-docstring

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -17,6 +17,10 @@ def mark_dataframe_tests_as_xfail(request):
                                             originalname == 'test_cast'):
         request.node.add_marker(
             pytest.mark.xfail(reason='DuckDB column binding error'))
+    if source == 'gateway-over-datafusion':
+        if originalname in ['test_data_source_schema', 'test_data_source_filter', 'test_table',
+                            'test_table_schema', 'test_table_filter']:
+            request.node.add_marker(pytest.mark.xfail(reason='Gateway internal iterating error'))
 
 
 # pylint: disable=missing-function-docstring

--- a/src/gateway/tests/test_sql_api.py
+++ b/src/gateway/tests/test_sql_api.py
@@ -24,6 +24,7 @@ def mark_tests_as_xfail(request):
         if path.stem in ['02', '04', '15', '16', '17', '18', '20', '21', '22']:
             request.node.add_marker(pytest.mark.xfail(reason='DuckDB needs Delim join'))
     if source == 'gateway-over-datafusion':
+        pytest.importorskip("datafusion.substrait")
         if originalname == 'test_count':
             request.node.add_marker(pytest.mark.xfail(reason='COUNT() not implemented'))
         if originalname in ['test_tpch']:

--- a/src/gateway/tests/test_sql_api.py
+++ b/src/gateway/tests/test_sql_api.py
@@ -23,6 +23,32 @@ def mark_tests_as_xfail(request):
         path = request.getfixturevalue('path')
         if path.stem in ['02', '04', '15', '16', '17', '18', '20', '21', '22']:
             request.node.add_marker(pytest.mark.xfail(reason='DuckDB needs Delim join'))
+    if source == 'gateway-over-datafusion':
+        if originalname == 'test_count':
+            request.node.add_marker(pytest.mark.xfail(reason='COUNT() not implemented'))
+        if originalname in ['test_tpch']:
+            path = request.getfixturevalue('path')
+            if path.stem in ['01']:
+                request.node.add_marker(pytest.mark.xfail(reason='COUNT() not implemented'))
+            elif path.stem in ['07']:
+                request.node.add_marker(pytest.mark.xfail(reason='Projection uniqueness error'))
+            elif path.stem in ['08']:
+                request.node.add_marker(pytest.mark.xfail(reason='aggregation error'))
+            elif path.stem in ['09']:
+                request.node.add_marker(pytest.mark.xfail(reason='instr not implemented'))
+            elif path.stem in ['11', '15']:
+                request.node.add_marker(pytest.mark.xfail(reason='first not implemented'))
+            elif path.stem in ['13']:
+                request.node.add_marker(pytest.mark.xfail(reason='not rlike not implemented'))
+            elif path.stem in ['16']:
+                request.node.add_marker(pytest.mark.xfail(reason='mark join not implemented'))
+            elif path.stem in ['18']:
+                request.node.add_marker(pytest.mark.xfail(reason='out of bounds error'))
+            elif path.stem in ['19']:
+                request.node.add_marker(pytest.mark.xfail(reason='multiargument OR not supported'))
+            elif path.stem in ['02', '04', '17', '20', '21', '22']:
+                request.node.add_marker(pytest.mark.xfail(reason='DataFusion needs Delim join'))
+            request.node.add_marker(pytest.mark.xfail(reason='Gateway internal iterating error'))
 
 
 # pylint: disable=missing-function-docstring

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -14,18 +14,23 @@ def mark_tests_as_xfail(request):
     """Marks a subset of tests as expected to be fail."""
     source = request.getfixturevalue('source')
     originalname = request.keywords.node.originalname
-    if source == 'gateway-over-duckdb' and originalname in [
-        'test_query_02', 'test_query_03', 'test_query_05', 'test_query_07', 'test_query_08',
-        'test_query_09', 'test_query_10', 'test_query_11', 'test_query_12', 'test_query_14',
-        'test_query_15', 'test_query_17', 'test_query_18', 'test_query_20', 'test_query_21',
-        'test_query_22']:
-        request.node.add_marker(pytest.mark.xfail(reason='DuckDB binder error'))
-    if source == 'gateway-over-duckdb' and originalname == 'test_query_04':
-        request.node.add_marker(pytest.mark.xfail(reason='deduplicate not implemented'))
-    if source == 'gateway-over-duckdb' and originalname == 'test_query_13':
-        request.node.add_marker(pytest.mark.xfail(reason='function rlike not implemented'))
-    if source == 'gateway-over-duckdb' and originalname in ['test_query_16', 'test_query_19']:
-        request.node.add_marker(pytest.mark.xfail(reason='function in not implemented'))
+    if source == 'gateway-over-duckdb':
+        if originalname in [
+            'test_query_02', 'test_query_03', 'test_query_05', 'test_query_07', 'test_query_08',
+            'test_query_09', 'test_query_10', 'test_query_11', 'test_query_12', 'test_query_14',
+            'test_query_15', 'test_query_17', 'test_query_18', 'test_query_20', 'test_query_21',
+            'test_query_22']:
+            request.node.add_marker(pytest.mark.xfail(reason='DuckDB binder error'))
+        if originalname == 'test_query_04':
+            request.node.add_marker(pytest.mark.xfail(reason='deduplicate not implemented'))
+        if originalname in ['test_query_12', 'test_query_14']:
+            request.node.add_marker(pytest.mark.xfail(reason='function when not implemented'))
+        if originalname == 'test_query_13':
+            request.node.add_marker(pytest.mark.xfail(reason='function rlike not implemented'))
+        if originalname in ['test_query_16', 'test_query_19']:
+            request.node.add_marker(pytest.mark.xfail(reason='function in not implemented'))
+    if source == 'gateway-over-datafusion':
+        request.node.add_marker(pytest.mark.xfail(reason='gateway internal error'))
 
 
 class TestTpchWithDataFrameAPI:

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -30,6 +30,7 @@ def mark_tests_as_xfail(request):
         if originalname in ['test_query_16', 'test_query_19']:
             request.node.add_marker(pytest.mark.xfail(reason='function in not implemented'))
     if source == 'gateway-over-datafusion':
+        pytest.importorskip("datafusion.substrait")
         request.node.add_marker(pytest.mark.xfail(reason='gateway internal error'))
 
 


### PR DESCRIPTION
There is one register_table call that uses format (in spark_to_substrait).

This fixes that and marks the tests that now pass again as passing.

