### PR TITLE
feat:  split the tests by backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
+        source: ["general", "spark", "gateway-over-duckdb", "gateway-over-datafusion"]
         python: ["3.10"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -36,4 +37,4 @@ jobs:
       - name: Run tests
         shell: bash -el {0}
         run: |
-          pytest
+          pytest -m ${{ matrix.source }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,13 @@ test = ["pytest >= 7.0.0"]
 [tool.pytest.ini_options]
 pythonpath = "src"
 addopts = "--ignore=third_party"
+markers = [
+  "spark: mark a test as running against Spark",
+  "gateway-over-arrow: mark a test as running against the gateway using Arrow",
+  "gateway-over-duckdb: mark a test as running against the gateway using DuckDB",
+  "gateway-over-datafusion: mark a test as running against the gateway using DataFusion",
+  "general: mark a test as not specific to a backend",
+]
 
 [build-system]
 requires = ["setuptools>=61.0.0", "setuptools_scm[toml]>=6.2.0"]

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Test fixtures for pytest of the gateway server."""
+import re
 from pathlib import Path
 
 import pytest
@@ -88,6 +89,15 @@ def schema_users():
 def source(request) -> str:
     """Provides the source (backend) to be used."""
     return request.param
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if 'source' in getattr(item, 'fixturenames', ()):
+            source = re.search(r'\[([^,]+).*?]$', item.name).group(1)
+            item.add_marker(source)
+        else:
+            item.add_marker('general')
 
 
 @pytest.fixture(scope='session')

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -15,6 +15,15 @@ from pyspark.sql.pandas.types import from_arrow_schema
 from pyspark.sql.session import SparkSession
 
 
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if 'source' in getattr(item, 'fixturenames', ()):
+            source = re.search(r'\[([^,]+?)(-\d+)?]$', item.name).group(1)
+            item.add_marker(source)
+            continue
+        item.add_marker('general')
+
+
 # ruff: noqa: T201
 def _create_local_spark_session() -> SparkSession:
     """Creates a local spark session for testing."""
@@ -89,15 +98,6 @@ def schema_users():
 def source(request) -> str:
     """Provides the source (backend) to be used."""
     return request.param
-
-
-def pytest_collection_modifyitems(items):
-    for item in items:
-        if 'source' in getattr(item, 'fixturenames', ()):
-            source = re.search(r'\[([^,]+).*?]$', item.name).group(1)
-            item.add_marker(source)
-        else:
-            item.add_marker('general')
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
This will allow individual test suites to be more rapidly iterated on.


To use, specify the desired source as an argument to pytest:

`pytest -m gateway-over-duckdb`

or

`pytest -m general`
