### PR TITLE
feat: implement the SparkConnect in function

### DIFF
--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -15,6 +15,7 @@ class ConversionOptions:
         self.use_named_table_workaround = False
         self.needs_scheme_in_path_uris = False
         self.use_emits_instead_of_direct = False
+        self.use_switch_expressions_where_possible = True
 
         self.return_names_with_types = False
 
@@ -42,4 +43,5 @@ def duck_db():
     """Return standard options to connect to a DuckDB backend."""
     options = ConversionOptions(backend=BackendOptions(Backend.DUCKDB))
     options.return_names_with_types = True
+    options.use_switch_expressions_where_possible = False
     return options

--- a/src/gateway/converter/substrait_builder.py
+++ b/src/gateway/converter/substrait_builder.py
@@ -141,6 +141,18 @@ def greatest_function(greater_function_info: ExtensionFunction, expr1: algebra_p
     )
 
 
+def equal_function(function_info: ExtensionFunction,
+                   expr1: algebra_pb2.Expression,
+                   expr2: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Construct a Substrait min expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=expr1),
+                   algebra_pb2.FunctionArgument(value=expr2)]))
+
+
 def greater_or_equal_function(function_info: ExtensionFunction,
                               expr1: algebra_pb2.Expression,
                               expr2: algebra_pb2.Expression) -> algebra_pb2.Expression:
@@ -221,6 +233,11 @@ def rpad_function(function_info: ExtensionFunction,
             algebra_pb2.FunctionArgument(value=cast_operation(count, integer_type())),
             algebra_pb2.FunctionArgument(
                 value=cast_operation(string_literal(pad_string), cast_type))]))
+
+
+def bool_literal(val: bool) -> algebra_pb2.Expression:
+    """Construct a Substrait boolean literal expression."""
+    return algebra_pb2.Expression(literal=algebra_pb2.Expression.Literal(boolean=val))
 
 
 def string_literal(val: str) -> algebra_pb2.Expression:

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -18,17 +18,13 @@ def mark_tests_as_xfail(request):
         if originalname in [
             'test_query_02', 'test_query_03', 'test_query_05', 'test_query_07', 'test_query_08',
             'test_query_09', 'test_query_10', 'test_query_11', 'test_query_12', 'test_query_14',
-            'test_query_15', 'test_query_17', 'test_query_18', 'test_query_20', 'test_query_21',
-            'test_query_22']:
+            'test_query_15', 'test_query_16', 'test_query_17', 'test_query_18', 'test_query_19',
+            'test_query_20', 'test_query_21', 'test_query_22']:
             request.node.add_marker(pytest.mark.xfail(reason='DuckDB binder error'))
         if originalname == 'test_query_04':
             request.node.add_marker(pytest.mark.xfail(reason='deduplicate not implemented'))
-        if originalname in ['test_query_12', 'test_query_14']:
-            request.node.add_marker(pytest.mark.xfail(reason='function when not implemented'))
         if originalname == 'test_query_13':
             request.node.add_marker(pytest.mark.xfail(reason='function rlike not implemented'))
-        if originalname in ['test_query_16', 'test_query_19']:
-            request.node.add_marker(pytest.mark.xfail(reason='function in not implemented'))
     if source == 'gateway-over-datafusion':
         pytest.importorskip("datafusion.substrait")
         request.node.add_marker(pytest.mark.xfail(reason='gateway internal error'))


### PR DESCRIPTION
There are two implementations here.  For cases where the backend supports
switch expressions we try that first (only works with literal values).  Failing that
a heavier weight if-then expression is crafted instead.
